### PR TITLE
Make hinters independent

### DIFF
--- a/hinting/dhcp.go
+++ b/hinting/dhcp.go
@@ -178,7 +178,7 @@ func parseBootstrapVendorOption(optionBytes []byte) (ip net.IP, port int, err er
 			"unexpected Vendor-ID, PEN:%d", PEN)
 		return
 	}
-	if offset+1 >= buffLen {
+	if offset+1 > buffLen {
 		err = fmt.Errorf("failed to parse DHCP Vendor Specific Option (125), " +
 			"missing data length")
 		return

--- a/hinting/dhcp.go
+++ b/hinting/dhcp.go
@@ -124,11 +124,12 @@ func (g *DHCPHintGenerator) dispatchDNSInfo(ack *dhcpv4.DHCPv4, dnsChan chan<- D
 	}
 	dnsInfoWriters.Add(1)
 	select {
-	case dnsChan <- dnsInfo:
-		dnsInfoWriters.Done()
 	case <-dnsInfoDone:
-		dnsInfoWriters.Done()
+		// Ignore dnsInfo value, done publishing
+	default:
+		dnsChan <- dnsInfo
 	}
+	dnsInfoWriters.Done()
 }
 
 func parseBootstrapVendorOption(optionBytes []byte) (ip net.IP, port int, err error) {

--- a/hinting/dhcp_request.go
+++ b/hinting/dhcp_request.go
@@ -20,6 +20,8 @@
 package hinting
 
 import (
+	"golang.org/x/sys/unix"
+
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/client4"
 	"github.com/scionproto/scion/go/lib/common"
@@ -32,10 +34,12 @@ func (g *DHCPHintGenerator) sendReceive(p *dhcpv4.DHCPv4, ifname string) (*dhcpv
 	if err != nil {
 		return nil, common.NewBasicError("DHCP hinter failed to open broadcast sender socket", err)
 	}
+	defer unix.Close(sender)
 	receiver, err := client4.MakeListeningSocket(g.iface.Name)
 	if err != nil {
 		return nil, common.NewBasicError("DHCP hinter failed to open receiver socket", err)
 	}
+	defer unix.Close(receiver)
 	ack, err := client.SendReceive(sender, receiver, p, dhcpv4.MessageTypeAck)
 	if err != nil {
 		return nil, common.NewBasicError("DHCP hinter failed to send inform request", err)

--- a/hinting/dhcp_request_pf_ip.go
+++ b/hinting/dhcp_request_pf_ip.go
@@ -20,6 +20,7 @@ package hinting
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net"
 	"time"
 
@@ -138,8 +139,8 @@ func sendReceive(sendFd, recvFd int, raddr, laddr *net.UDPAddr, packet *dhcpv4.D
 			}
 			udph := buf[iph.Len:n]
 			if 8 > len(udph) {
-				errs <- fmt.Errorf("failed to parse DHCP reply packet from %s: " +
-					"invalid UDP header length", ipAddr)
+				errs <- fmt.Errorf("failed to parse DHCP reply packet: " +
+					"invalid UDP header length")
 				return
 			}
 			// check source and destination ports
@@ -163,8 +164,8 @@ func sendReceive(sendFd, recvFd int, raddr, laddr *net.UDPAddr, packet *dhcpv4.D
 			// UDP checksum is not checked
 			payloadOffsetEnd := iph.Len+pLen
 			if payloadOffsetEnd > n || payloadOffsetEnd > iph.TotalLen {
-				errs <- fmt.Errorf("failed to parse DHCP reply packet from %s: " +
-					"invalid UDP payload length", ipAddr)
+				errs <- fmt.Errorf("failed to parse DHCP reply packet: " +
+					"invalid UDP payload length")
 				return
 			}
 			payload := buf[iph.Len+8 : payloadOffsetEnd]

--- a/hinting/dhcp_request_pf_ip.go
+++ b/hinting/dhcp_request_pf_ip.go
@@ -23,10 +23,11 @@ import (
 	"net"
 	"time"
 
-	"github.com/insomniacslk/dhcp/dhcpv4"
-	"github.com/scionproto/scion/go/lib/common"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 func (g *DHCPHintGenerator) sendReceive(p *dhcpv4.DHCPv4, ifname string) (*dhcpv4.DHCPv4, error) {
@@ -136,6 +137,11 @@ func sendReceive(sendFd, recvFd int, raddr, laddr *net.UDPAddr, packet *dhcpv4.D
 				continue
 			}
 			udph := buf[iph.Len:n]
+			if 8 > len(udph) {
+				errs <- fmt.Errorf("failed to parse DHCP reply packet from %s: " +
+					"invalid UDP header length", ipAddr)
+				return
+			}
 			// check source and destination ports
 			srcPort := int(binary.BigEndian.Uint16(udph[0:2]))
 			expectedSrcPort := dhcpv4.ServerPort
@@ -153,9 +159,15 @@ func sendReceive(sendFd, recvFd int, raddr, laddr *net.UDPAddr, packet *dhcpv4.D
 			if dstPort != expectedDstPort {
 				continue
 			}
-			// UDP checksum is not checked
 			pLen := int(binary.BigEndian.Uint16(udph[4:6]))
-			payload := buf[iph.Len+8 : iph.Len+pLen]
+			// UDP checksum is not checked
+			payloadOffsetEnd := iph.Len+pLen
+			if payloadOffsetEnd > n || payloadOffsetEnd > iph.TotalLen {
+				errs <- fmt.Errorf("failed to parse DHCP reply packet from %s: " +
+					"invalid UDP payload length", ipAddr)
+				return
+			}
+			payload := buf[iph.Len+8 : payloadOffsetEnd]
 
 			response, innerErr = dhcpv4.FromBytes(payload)
 			if innerErr != nil {

--- a/hinting/dns.go
+++ b/hinting/dns.go
@@ -31,10 +31,6 @@ const (
 	discoveryDDDSDNSName    string = "x-sciondiscovery:tcp"
 )
 
-var (
-	dnsServersChan = make(chan DNSInfo)
-)
-
 type DNSInfo struct {
 	resolvers     []string
 	searchDomains []string
@@ -61,8 +57,8 @@ func (g *DNSSDHintGenerator) Generate(ipHintsChan chan<- net.TCPAddr) {
 	if !g.cfg.EnableSRV && !g.cfg.EnableSD && !g.cfg.EnableNAPTR {
 		return
 	}
-	go getLocalDNSConfig()
-	for dnsServer := range dnsServersChan {
+	dnsChan := dispatcher.getDNSConfig()
+	for dnsServer := range dnsChan {
 		log.Info("Using following resolvers for DNS hinting", "resolvers", dnsServer.resolvers)
 		for _, resolver := range dnsServer.resolvers {
 			for _, domain := range dnsServer.searchDomains {
@@ -103,7 +99,11 @@ func resolveDNS(resolver, query string, resultPort uint16, dnsRR uint16, ipHints
 	msg.RecursionDesired = true
 	result, err := dns.Exchange(msg, resolver+":53")
 	if err != nil {
-		log.Error("DNS-SD failed", "err", err)
+		if dnsRR != dns.TypeAAAA {
+			log.Error("DNS-SD failed", "err", err)
+		} else {
+			log.Info("DNS-SD failed for IPv6", "err", err)
+		}
 		return
 	}
 

--- a/hinting/dns.go
+++ b/hinting/dns.go
@@ -178,7 +178,7 @@ func queryTXTPortRecord(resolver, query string) (resultPort uint16) {
 	for _, ans := range res.Answer {
 		if txtRecords, ok := ans.(*dns.TXT); ok {
 			for _, txt := range txtRecords.Txt {
-				port, err := strconv.ParseInt(txt, 10, 16)
+				port, err := strconv.ParseUint(txt, 10, 16)
 				if err != nil {
 					log.Error("DNS-SD failed to convert TXT record to a valid port", "err", err)
 					continue

--- a/hinting/dns_config_windows.go
+++ b/hinting/dns_config_windows.go
@@ -71,7 +71,7 @@ func getDNSConfigIPHlpAPI() (dnsInfo *DNSInfo) {
 }
 
 func getDNSConfigResolv() (dnsInfo *DNSInfo) {
-	log.Error("IP Helper API not supported on current OS", "err",
+	log.Error("Resolv not supported on current OS", "err",
 		errors.New("only reading from IP_ADAPTER_ADDRESSES is implemented for this OS,"+
 			" use getDNSConfigIPHlpAPI to get local DNS config"))
 	return nil

--- a/main.go
+++ b/main.go
@@ -49,12 +49,12 @@ func realMain() int {
 		return v
 	}
 	if err := libconfig.LoadFile(env.ConfigFile(), &cfg); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintf(os.Stderr, "Unable to load config: %v\n", err)
 		return 1
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintf(os.Stderr, "fatal error: %v\n", err)
 		return 1
 	}
 	cfg.InterfaceName = *ifaceName


### PR DESCRIPTION
Exit early when all hinters returned.

Make hinters relying on DNS information independent of the source of the information (and in particular independent of the DHCP hinter), and also independent of each other.

Hinters relying on DNS information can be enabled in parallel and each does process the information at its own rate by subscribing to a publisher aggregating the DNS server and search domain information available.