### PR TITLE
Verify signed topology file against TRC

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -97,6 +97,7 @@ pkg_deb(
     depends = [
         "scion-dispatcher",
         "scion-daemon",
+        "scion-tools",
         "openssl",
     ],
     description = PKG_DESCRIPTION,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -97,6 +97,7 @@ pkg_deb(
     depends = [
         "scion-dispatcher",
         "scion-daemon",
+        "openssl",
     ],
     description = PKG_DESCRIPTION,
     homepage = PKG_HOMEPAGE,

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -86,7 +86,7 @@ OuterLoop:
 			if serverAddr.Port == 0 {
 				serverAddr.Port = int(hinting.DiscoveryPort)
 			}
-			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, serverAddr)
+			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, cfg.Insecure, serverAddr)
 			if err != nil {
 				return err
 			}

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -44,8 +44,8 @@ func NewBootstrapper(cfg *config.Config) (*Bootstrapper, error) {
 	log.Debug("Configuration loaded", "cfg", cfg)
 
 	// Ensure working directory exists
-	if _, err := os.Stat(config.WorkingDir); os.IsNotExist(err) {
-		err := os.Mkdir(config.WorkingDir, 0775)
+	if _, err := os.Stat(cfg.WorkingDir()); os.IsNotExist(err) {
+		err := os.Mkdir(cfg.WorkingDir(), 0775)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create bootstrapper working directory: err: %w", err)
 		}
@@ -96,7 +96,7 @@ OuterLoop:
 			if serverAddr.Port == 0 {
 				serverAddr.Port = int(hinting.DiscoveryPort)
 			}
-			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, config.WorkingDir, cfg.SecurityMode, serverAddr)
+			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, cfg.WorkingDir(), cfg.SecurityMode, serverAddr)
 			if err != nil {
 				return err
 			}

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -86,7 +86,7 @@ OuterLoop:
 			if serverAddr.Port == 0 {
 				serverAddr.Port = int(hinting.DiscoveryPort)
 			}
-			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, cfg.Insecure, serverAddr)
+			err := fetcher.FetchConfiguration(cfg.SciondConfigDir, cfg.SecurityMode, serverAddr)
 			if err != nil {
 				return err
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pelletier/go-toml"
@@ -64,7 +64,7 @@ type Config struct {
 }
 
 func (c Config) WorkingDir() string {
-	return path.Join(c.SciondConfigDir, "bootstrapper")
+	return filepath.Join(c.SciondConfigDir, "bootstrapper")
 }
 
 // LogConfig is the configuration for the logger.

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,6 @@ var (
 	helpConfig    bool
 	configPath    string
 	IfaceName     string
-	WorkingDir    string
 )
 
 type Config struct {
@@ -62,6 +61,10 @@ type Config struct {
 	DNSSD           hinting.DNSHintGeneratorConf  `toml:"dnssd"`
 	MDNS            hinting.MDNSHintGeneratorConf `toml:"mdns"`
 	Logging         LogConfig                     `toml:"log,omitempty"`
+}
+
+func (c Config) WorkingDir() string {
+	return path.Join(c.SciondConfigDir, "bootstrapper")
 }
 
 // LogConfig is the configuration for the logger.
@@ -129,7 +132,6 @@ func (cfg *Config) InitDefaults() {
 	if cfg.SecurityMode == "" {
 		cfg.SecurityMode = Permissive
 	}
-	WorkingDir = path.Join(cfg.SciondConfigDir, "bootstrapper")
 }
 
 func (cfg *Config) Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pelletier/go-toml"
@@ -49,6 +50,7 @@ var (
 	helpConfig    bool
 	configPath    string
 	IfaceName     string
+	WorkingDir    string
 )
 
 type Config struct {
@@ -127,6 +129,7 @@ func (cfg *Config) InitDefaults() {
 	if cfg.SecurityMode == "" {
 		cfg.SecurityMode = Permissive
 	}
+	WorkingDir = path.Join(cfg.SciondConfigDir, "bootstrapper")
 }
 
 func (cfg *Config) Validate() error {

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ var (
 type Config struct {
 	InterfaceName   string
 	SciondConfigDir string                        `toml:"sciond_config_dir"`
+	Insecure        bool                          `toml:"insecure,omitempty"`
 	MOCK            hinting.MOCKHintGeneratorConf `toml:"mock"`
 	DHCP            hinting.DHCPHintGeneratorConf `toml:"dhcp"`
 	DNSSD           hinting.DNSHintGeneratorConf  `toml:"dnssd"`

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,14 @@ const (
 	DefaultLogLevel = "info"
 )
 
+type SecurityMode string
+
+const (
+	Strict     SecurityMode = "strict"     // only store a TRC if it validates against an existing TRC update chain
+	Permissive SecurityMode = "permissive" // only store a TRC if it does not conflict with an existing TRC update chain
+	Insecure   SecurityMode = "insecure"   // store any TRC, mark it as insecure, don't validate the topology signature
+)
+
 var (
 	version       bool
 	versionString string
@@ -46,7 +54,7 @@ var (
 type Config struct {
 	InterfaceName   string
 	SciondConfigDir string                        `toml:"sciond_config_dir"`
-	Insecure        bool                          `toml:"insecure,omitempty"`
+	SecurityMode    SecurityMode                  `toml:"security_mode,omitempty"`
 	MOCK            hinting.MOCKHintGeneratorConf `toml:"mock"`
 	DHCP            hinting.DHCPHintGeneratorConf `toml:"dhcp"`
 	DNSSD           hinting.DNSHintGeneratorConf  `toml:"dnssd"`
@@ -115,6 +123,9 @@ func (cfg *Config) InitDefaults() {
 	}
 	if cfg.SciondConfigDir == "" {
 		cfg.SciondConfigDir = "."
+	}
+	if cfg.SecurityMode == "" {
+		cfg.SecurityMode = Permissive
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -102,7 +101,7 @@ func CheckFlags(cfg *Config) (int, bool) {
 }
 
 func LoadFile(cfg *Config) error {
-	raw, err := ioutil.ReadFile(configPath)
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		return err
 	}

--- a/config/sample.go
+++ b/config/sample.go
@@ -18,8 +18,8 @@ const bootstrapperSample = `
 # The folder where the retrieved topology and certificates are stored (default ".")
 sciond_config_dir = "."
 
-# Skip the verification of the signature of the configuration file using the TRC (default false)
-insecure = false
+# Set the verification behavior of the signature of the configuration file using the TRC (default permissive)
+security_mode = insecure
 
 # Discovery mechanisms
 [mock]

--- a/config/sample.go
+++ b/config/sample.go
@@ -18,6 +18,9 @@ const bootstrapperSample = `
 # The folder where the retrieved topology and certificates are stored (default ".")
 sciond_config_dir = "."
 
+# Skip the verification of the signature of the configuration file using the TRC (default false)
+insecure = false
+
 # Discovery mechanisms
 [mock]
 	# Whether to enable the fake discovery or not (default false)

--- a/fetcher/openssl_cmds.go
+++ b/fetcher/openssl_cmds.go
@@ -1,0 +1,40 @@
+package fetcher
+
+import (
+	"context"
+	"os/exec"
+)
+
+// opensslCMSVerify uses the openssl cms module to verify the signature of signedTopology
+// using the CA bundle rootCertsBundlePath.
+func opensslCMSVerify(ctx context.Context, signedTopology, rootCertsBundlePath string) error {
+	return exec.CommandContext(ctx, "openssl", "cms", "-verify",
+		"-in", signedTopology, "-CAfile", rootCertsBundlePath, "-purpose", "any").Run()
+}
+
+// opensslCMSVerifyOutput uses the openssl cms module to outputs the unverified signedTopologyPath payload
+// without any signature verification to unverifiedTopologyPath.
+func opensslCMSNoVerifyOutput(ctx context.Context, signedTopologyPath, unverifiedTopologyPath string) error {
+	return exec.CommandContext(ctx, "openssl", "cms", "-verify", "-noverify",
+		"-in", signedTopologyPath, "-text", "-noout", "-out", unverifiedTopologyPath).Run()
+}
+
+// opensslCMSVerifyOutput uses the openssl cms module to verify the signature of signedTopology
+// using the CA bundle rootCertsBundlePath, and outputs the verified payload to verifiedTopology.
+func opensslCMSVerifyOutput(ctx context.Context, signedTopology, rootCertsBundlePath, verifiedTopology string) error {
+	return exec.CommandContext(ctx, "openssl", "cms", "-verify", "-in", signedTopology,
+		"-CAfile", rootCertsBundlePath, "-purpose", "any", "-noout", "-text", "-out", verifiedTopology).Run()
+}
+
+// opensslSMIMEPk7out uses the opnessl smime module to detach the signature on signedTopology in the PKCS#7 format.
+func opensslSMIMEPk7out(ctx context.Context, signedTopology, detachedSignaturePath string) error {
+	return exec.CommandContext(ctx, "openssl", "smime", "-pk7out",
+		"-in", signedTopology, "-out", detachedSignaturePath).Run()
+}
+
+// opensslPKCS7Certs uses the openssl pkcs7 module to extract the certificate bundle into asCertHumanChain
+// from the detached signature at detachedSignaturePath.
+func opensslPKCS7Certs(ctx context.Context, detachedSignaturePath, asCertHumanChain string) error {
+	return exec.CommandContext(ctx, "openssl", "pkcs7", "-in", detachedSignaturePath,
+		"-inform", "PEM", "-print_certs", "-out", asCertHumanChain).Run()
+}

--- a/fetcher/openssl_cmds.go
+++ b/fetcher/openssl_cmds.go
@@ -5,20 +5,6 @@ import (
 	"os/exec"
 )
 
-// opensslCMSVerify uses the openssl cms module to verify the signature of signedTopology
-// using the CA bundle rootCertsBundlePath.
-func opensslCMSVerify(ctx context.Context, signedTopology, rootCertsBundlePath string) error {
-	return exec.CommandContext(ctx, "openssl", "cms", "-verify",
-		"-in", signedTopology, "-CAfile", rootCertsBundlePath, "-purpose", "any").Run()
-}
-
-// opensslCMSVerifyOutput uses the openssl cms module to outputs the unverified signedTopologyPath payload
-// without any signature verification to unverifiedTopologyPath.
-func opensslCMSNoVerifyOutput(ctx context.Context, signedTopologyPath, unverifiedTopologyPath string) error {
-	return exec.CommandContext(ctx, "openssl", "cms", "-verify", "-noverify",
-		"-in", signedTopologyPath, "-text", "-noout", "-out", unverifiedTopologyPath).Run()
-}
-
 // opensslCMSVerifyOutput uses the openssl cms module to verify the signature of signedTopology
 // using the CA bundle rootCertsBundlePath, and outputs the verified payload to verifiedTopology.
 func opensslCMSVerifyOutput(ctx context.Context, signedTopology, rootCertsBundlePath, verifiedTopology string) error {

--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -123,7 +123,7 @@ func verifyTopologySignature(bootstrapperPath, unverifiedIA,
 	rawASCertChain := strings.Join(rawCerts, "\n")
 	_ = os.WriteFile(asCertChainPath, []byte(rawASCertChain), 0666)
 
-	// verify AS certificate chain back to TRC(s):
+	// verify AS certificate chain back to TRC(s) follows the SCION CP PKI rules about cert type, key usage:
 	err = spkiCertVerify(ctx, strings.Join(trcPaths, ","), asCertChainPath)
 	if err != nil {
 		return fmt.Errorf("certificate validation failed: unable to validate certificate chain: %w", err)

--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"sort"
@@ -98,14 +98,18 @@ func verifyTopologySignature(outputPath, signedTopologyPath, trustAnchorTRCPath 
 }
 
 func verifySignature(outputPath string) error {
-	files, err := ioutil.ReadDir(path.Join(outputPath, "certs"))
+	files, err := os.ReadDir(path.Join(outputPath, "certs"))
 	if err != nil {
 		return err
 	}
 	var trcs sortedFiles
 	for _, file := range files {
-		if file.Mode().IsRegular() {
-			trcs = append(trcs, file)
+		fileInfo, err := file.Info()
+		if err != nil {
+			continue
+		}
+		if fileInfo.Mode().IsRegular() {
+			trcs = append(trcs, fileInfo)
 		}
 	}
 	signedTopologyPath := path.Join(outputPath, signedTopologyFileName)

--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -1,0 +1,138 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"sort"
+	"time"
+)
+
+func verifyTopologySignature(outputPath, signedTopologyPath, trustAnchorTRCPath string) error {
+	// The signature is of the type:
+	// openssl cms -sign -text -in topology -out topology.signed -inkey as.key -signer as.cert.pem -certfile ca.cert.pem
+
+	// Low-code implementation, verify the signature only using standard tools
+	// and the existing functionality of the `scion-pki` tool to verify a two level certificate chain
+	// consisting of (as_cert, ca_cert) back to a TRC (chain) with included root_certs.
+
+	// Signature verification should complete in a timely manner since it is a local operation
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := exec.CommandContext(ctx, "which", "openssl", "scion-pki").Run()
+	if err != nil {
+		return fmt.Errorf("signature verification failed:"+
+			"standard tools `openssl`, or `scion-pki` not found: %w", err)
+	}
+
+	_, trcFileName := path.Split(trustAnchorTRCPath)
+	rootCertsBundleName := trcFileName + ".certs.pem"
+	rootCertsBundlePath := path.Join(outputPath, rootCertsBundleName)
+	// extract TRC certificates:
+	err = exec.CommandContext(ctx, "scion-pki", "trc", "extract", "certificates",
+		trustAnchorTRCPath, "-o", rootCertsBundlePath).Run()
+	if err != nil {
+		return fmt.Errorf("signature verification failed: unable to extract root certificates from TRC %s: %w",
+			trustAnchorTRCPath, err)
+	}
+
+	// verify signature:
+	err = exec.CommandContext(ctx, "openssl", "cms", "-verify",
+		"-in", signedTopologyPath, "-CAfile", rootCertsBundlePath, "-purpose", "any",).Run()
+	if err != nil {
+		return fmt.Errorf("signature verification failed: signature verification failed: %w", err)
+	}
+
+	detachedSignaturePath := path.Join(outputPath, "detached_signature.p7s")
+	// detach signature for further validation:
+	err = exec.CommandContext(ctx, "openssl", "smime", "-pk7out",
+		"-in", signedTopologyPath, "-out", detachedSignaturePath).Run()
+	if err != nil {
+		return fmt.Errorf("certificate validation failed: unable to detach signature: %w", err)
+	}
+
+	asCertChain := path.Join(outputPath, "as_cert_chain.pem")
+	// collect included certificates from detached signature:
+	shellCommand := fmt.Sprintf(
+		"openssl pkcs7 -in %s -inform PEM -print_certs | grep -v \"issuer\\|subject\" | grep . > %s",
+		detachedSignaturePath, asCertChain)
+	err = exec.CommandContext(ctx, "bash", "-c", shellCommand).Run()
+	if err != nil {
+		return fmt.Errorf("certificate validation failed: "+
+			"unable to gather included certificates from signature: %w", err)
+	}
+
+	// verify AS certificate chain back to TRC:
+	err = exec.CommandContext(ctx, "scion-pki", "certificate", "verify",
+		"--trc", trustAnchorTRCPath, asCertChain).Run()
+	if err != nil {
+		return fmt.Errorf("certificate validation failed: unable to validate certificate chain: %w", err)
+	}
+
+	topologyPath := path.Join(outputPath, topologyJSONFileName)
+	// We now have a signed topology with a valid signature and a certificate chain back to a TRC, write out the payload
+	err = exec.CommandContext(ctx, "openssl", "cms", "-verify", "-in", signedTopologyPath,
+		"-CAfile", rootCertsBundlePath, "-purpose", "any", "-noout", "-text", "-out", topologyPath).Run()
+	if err != nil {
+		return fmt.Errorf("extracting signed payload failed: %w", err)
+	}
+	return nil
+}
+
+func verifySignature(outputPath string) error {
+	files, err := ioutil.ReadDir(path.Join(outputPath, "certs"))
+	if err != nil {
+		return err
+	}
+	var trcs sortedFiles
+	for _, file := range files {
+		if file.Mode().IsRegular() {
+			trcs = append(trcs, file)
+		}
+	}
+	signedTopologyPath := path.Join(outputPath, signedTopologyFileName)
+	// Check against most recently fetched TRC first
+	sort.Sort(sort.Reverse(trcs))
+	for _, trc := range trcs {
+		trustAnchorTRCPath := path.Join(outputPath, "certs", trc.Name())
+		// Try to verify signature against all available TRCs
+		err = verifyTopologySignature(outputPath, signedTopologyPath, trustAnchorTRCPath)
+		if err == nil {
+			break
+		}
+	}
+	return err
+}
+
+type sortedFiles []fs.FileInfo
+
+func (f sortedFiles) Len() int {
+	return len(f)
+}
+
+func (f sortedFiles) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+	return
+}
+
+func (f sortedFiles) Less(i, j int) bool {
+	return f[i].ModTime().Before(f[j].ModTime())
+}

--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -146,18 +146,17 @@ func verifyTopologySignature(bootstrapperPath, unverifiedIA,
 	return nil
 }
 
-func verifySignature(outputPath string) error {
-	signedTopologyPath := path.Join(outputPath, signedTopologyFileName)
+func verifyTRCUpdateChain(outputPath, candidateTRCPath string, strict bool) error {
+	// TODO: do the actual TRC update chain check
+	return fmt.Errorf("check not implemented: strict mode: %v", strict)
+}
 
-	bootstrapperPath := path.Join(outputPath, "bootstrapper")
-	err := os.Mkdir(bootstrapperPath, 0777)
-	if err != nil {
-		return fmt.Errorf("Failed to create bootstrapper intermediate directory: " +
-			"dir: %s, err: %w", bootstrapperPath, err)
-	}
+func verifySignature(outputPath, workingDir string) error {
+	signedTopologyPath := path.Join(workingDir, signedTopologyFileName)
+
 	timestamp := time.Now().Unix()
-	bootstrapperPath = path.Join(outputPath, "bootstrapper", fmt.Sprintf("verify-%d", timestamp))
-	err = os.Mkdir(bootstrapperPath, 0777)
+	bootstrapperPath := path.Join(workingDir, fmt.Sprintf("verify-%d", timestamp))
+	err := os.Mkdir(bootstrapperPath, 0775)
 	if err != nil {
 		return fmt.Errorf("Failed to create verify directory: dir: %s, err: %w", bootstrapperPath, err)
 	}

--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -17,6 +17,7 @@ package fetcher
 import (
 	"context"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/json"
 	"encoding/pem"
@@ -37,12 +38,10 @@ type topoIA struct {
 	IA string `json:"isd_as"`
 }
 
-func verifyTopologySignature(bootstrapperPath, unverifiedIA,
-	signedTopology, verifiedTopology string, trcPaths []string) error {
-
-	// TODO: change stringly typed function parameters
-
-	// The signature is of the type:
+// verifyTopologySignature verifies the signature of the signed topology in workingDir
+// and stores the verified topology the in outputPath.
+func verifyTopologySignature(outputPath, workingDir string) error {
+	// The signature is of the type `ecdsa-with-SHA256`:
 	// openssl cms -sign -text -in topology -out topology.signed -inkey as.key -signer as.cert.pem -certfile ca.cert.pem
 
 	// Verify the signature using openssl, and do some additional checks between the payload and the signer cert.
@@ -56,95 +55,119 @@ func verifyTopologySignature(bootstrapperPath, unverifiedIA,
 	for _, tool := range []string{"openssl", "scion-pki"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
-			return fmt.Errorf("signature verification failed: %w", err)
+			return err
 		}
 	}
 
-	// Verify signed payload:
-	if len(trcPaths) < 1 {
-		return fmt.Errorf("signature verification failed: TRC trust anchor required, none provided")
-	}
-	trustAnchorTRC := trcPaths[0]
-	_, trcFileName := path.Split(trustAnchorTRC)
-	rootCertsBundleName := trcFileName + ".certs.pem"
-	rootCertsBundlePath := path.Join(bootstrapperPath, rootCertsBundleName)
-	// extract TRC certificates:
-	err := spkiTRCExtractCerts(ctx, trustAnchorTRC, rootCertsBundlePath)
+	// Create verify directory
+	timestamp := time.Now().Unix()
+	verifyPath := path.Join(workingDir, fmt.Sprintf("verify-%d", timestamp))
+	err := os.Mkdir(verifyPath, 0775)
 	if err != nil {
-		return fmt.Errorf("signature verification failed: unable to extract root certificates from TRC %s: %w",
-			trustAnchorTRC, err)
+		return fmt.Errorf("failed to create verify directory: dir: %s, err: %w", verifyPath, err)
 	}
 
-	// verify signature:
-	err = opensslCMSVerify(ctx, signedTopology, rootCertsBundlePath)
-	if err != nil {
-		return fmt.Errorf("signature verification failed: signature verification failed: %w", err)
-	}
-
-	detachedSignaturePath := path.Join(bootstrapperPath, "detached_signature.p7s")
+	signedTopology := path.Join(workingDir, signedTopologyFileName)
+	detachedSignaturePath := path.Join(verifyPath, "detached_signature.p7s")
 	// detach signature for further validation:
 	err = opensslSMIMEPk7out(ctx, signedTopology, detachedSignaturePath)
 	if err != nil {
-		return fmt.Errorf("certificate validation failed: unable to detach signature: %w", err)
+		return fmt.Errorf("unable to detach signature: %w", err)
 	}
 
-	asCertHumanChain := path.Join(bootstrapperPath, "as_cert_chain.human.pem")
+	asCertHumanChain := path.Join(verifyPath, "as_cert_chain.human.pem")
 	// collect included certificates from detached signature:
 	err = opensslPKCS7Certs(ctx, detachedSignaturePath, asCertHumanChain)
 	if err != nil {
-		return fmt.Errorf("certificate validation failed: "+
-			"unable to gather included certificates from signature: %w", err)
+		return fmt.Errorf("unable to gather included certificates from signature: %w", err)
 	}
 
 	// Split signer and ca certificate
 	certs, rawCerts, err := getCertsFromBundle(asCertHumanChain)
 	if err != nil {
-		return fmt.Errorf("certificate validation failed: %w", err)
+		return err
 	}
 	asCert := certs[0]
 
-	// Check signer AS ID matches unverifiedIA
-	certSubjectASID := ""
-	OIDNameIA := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 55324, 1, 2, 1}
-	for _, dn := range asCert.Subject.Names {
-		if dn.Type.Equal(OIDNameIA) {
-			certSubjectASID = dn.Value.(string)
-			break
-		}
-	}
-	if certSubjectASID != unverifiedIA {
-		return fmt.Errorf("certificate validation failed: "+
-			"signer AS certificate subject does not match AS ID included in topology: "+
-			"expected: %s, actual: %s", unverifiedIA, certSubjectASID)
-	}
-
 	// Store certificate chain extracted from signature
-	asCertChainPath := path.Join(bootstrapperPath, "as_cert_chain.pem")
+	asCertChainPath := path.Join(verifyPath, "as_cert_chain.pem")
 	rawASCertChain := strings.Join(rawCerts, "\n")
 	_ = os.WriteFile(asCertChainPath, []byte(rawASCertChain), 0666)
 
-	// verify AS certificate chain back to TRC(s) follows the SCION CP PKI rules about cert type, key usage:
-	err = spkiCertVerify(ctx, strings.Join(trcPaths, ","), asCertChainPath)
+	// Get TRCs corresponding to signer IA
+	signerIA, signerTRCid, err := getCertIA(asCert)
 	if err != nil {
-		return fmt.Errorf("certificate validation failed: unable to validate certificate chain: %w", err)
+		return err
 	}
 
-	// We now have a signed topology with a valid signature and a certificate chain back to a TRC, write out the payload
-	err = opensslCMSVerifyOutput(ctx, signedTopology, rootCertsBundlePath, verifiedTopology)
+	trcs, err := getTRCsByISDid(outputPath, signerTRCid)
 	if err != nil {
-		return fmt.Errorf("extracting signed payload failed: %w", err)
+		return err
 	}
-	return nil
+	if len(trcs) == 0 {
+		return fmt.Errorf("unable to verify signature, no valid TRC found in %s,  ISD id: %d",
+			verifyPath, signerTRCid)
+	}
+	sortedTRCsPaths := sortTRCsFiles(trcs).Paths()
+
+	for i := len(sortedTRCsPaths) - 1; i > 0 && i > len(sortedTRCsPaths)-1-2; i-- {
+		// Try to verify signature against the two latest TRCs matching the ISD claimed by the signer.
+		// TRC validity (expiration and grace period) is checked by the call to `scion-pki`.
+		// The signer IA needs to match the IA in the topology of the payload.
+		trustAnchorTRC := sortedTRCsPaths[i]
+		_, trcFileName := path.Split(trustAnchorTRC)
+		rootCertsBundleName := trcFileName + ".certs.pem"
+		rootCertsBundlePath := path.Join(verifyPath, rootCertsBundleName)
+		// extract TRC certificates:
+		err = spkiTRCExtractCerts(ctx, trustAnchorTRC, rootCertsBundlePath)
+		if err != nil {
+			err = fmt.Errorf("unable to extract root certificates from TRC %s: %w",
+				trustAnchorTRC, err)
+			continue
+		}
+		// verify the AS certificate chain (but not the payload signature) back to TRC(s) follows the SCION CP PKI rules
+		// about cert type, key usage:
+		err = spkiCertVerify(ctx, strings.Join(sortedTRCsPaths[i:], ","), asCertChainPath)
+		if err != nil {
+			err = fmt.Errorf("unable to validate certificate chain: %w", err)
+			continue
+		}
+
+		unvalidatedTopologyPath := path.Join(verifyPath, topologyJSONFileName+".unvalidated")
+		// verify the signature and certificate chain back to a root certs bundle, write out the payload:
+		err = opensslCMSVerifyOutput(ctx, signedTopology, rootCertsBundlePath, unvalidatedTopologyPath)
+		if err != nil {
+			err = fmt.Errorf("verifying and extracting signed payload failed: %w", err)
+			continue
+		}
+
+		// Validate signer IA matches payload IA
+		err = checkTopoIA(unvalidatedTopologyPath, signerIA)
+		if err != nil {
+			rerr := os.Remove(unvalidatedTopologyPath)
+			log.Error("removing mismatching topology failed", "err", rerr)
+			continue
+		}
+		verifiedTopology := path.Join(outputPath, topologyJSONFileName)
+		err = os.Rename(unvalidatedTopologyPath, verifiedTopology)
+		if err != nil {
+			continue
+		}
+		break
+	}
+	return err
 }
 
+// getCertsFromBundle splits a certificate bundle consisting of an AS certificate and a CA certificate
+// into individual certificates and parses them.
 func getCertsFromBundle(asCertHumanChain string) ([]*x509.Certificate, []string, error) {
 	rawASCertHumanChain, _ := os.ReadFile(asCertHumanChain)
 	// Split signer and ca certificate
-	re := regexp.MustCompile("-*?BEGIN CERTIFICATE-*?\\n[\\s\\S]*-*?END CERTIFICATE-*?\\n")
+	re := regexp.MustCompile("-*?BEGIN CERTIFICATE-*?\\n[\\s\\S]*?-*?END CERTIFICATE-*?\\n")
 	matches := re.FindAllString(string(rawASCertHumanChain), -1)
 	if len(matches) != 2 {
-		return nil, nil, fmt.Errorf("unable to split certificate bundle: certificates included: %d",
-			len(matches))
+		return nil, nil, fmt.Errorf("unable to split certificate bundle %s: certificates included: %d",
+			asCertHumanChain, len(matches))
 	}
 
 	asCertRaw := []byte(matches[0])
@@ -168,12 +191,12 @@ func getCertsFromBundle(asCertHumanChain string) ([]*x509.Certificate, []string,
 	return []*x509.Certificate{cert, caCert}, matches, err
 }
 
+// verifyTRCUpdateChain verifies the TRC at candidateTRCPath has a valid update chain to the other TRCs of the same ISD.
 func verifyTRCUpdateChain(outputPath, candidateTRCPath string, strict bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	v, _ := os.ReadFile(candidateTRCPath)
-	var trc trcSummary
-	_, err := asn1.Unmarshal(v, &trc)
+	trc, err := getTRCSummary(v)
 	if err != nil {
 		return fmt.Errorf("validating TRC update chain failed: %w", err)
 	}
@@ -196,6 +219,46 @@ func verifyTRCUpdateChain(outputPath, candidateTRCPath string, strict bool) erro
 	return nil
 }
 
+// checkTopoIA checks that the expectedIA matches the IA in the topology file at topologyPath.
+func checkTopoIA(topologyPath, expectedIA string) error {
+	unverifiedTopo, err := os.ReadFile(topologyPath)
+	if err != nil {
+		return fmt.Errorf("reading unverified payload failed: %w", err)
+	}
+	topoIA := topoIA{}
+	err = json.Unmarshal(unverifiedTopo, &topoIA)
+	if err != nil {
+		return fmt.Errorf("parsing unverified payload failed: %w", err)
+	}
+	payloadIA := topoIA.IA
+
+	if expectedIA != payloadIA {
+		return fmt.Errorf("signer AS certificate subject does not match AS ID included in topology: "+
+			"expected: %s, actual: %s", expectedIA, payloadIA)
+	}
+	return nil
+}
+
+// getCertIA returns the IA property of subject of the certificate and the TRCid.
+func getCertIA(cert *x509.Certificate) (IA string, TRCid int64, err error) {
+	OIDNameIA := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 55324, 1, 2, 1}
+	for _, dn := range cert.Subject.Names {
+		if dn.Type.Equal(OIDNameIA) {
+			IA = dn.Value.(string)
+			break
+		}
+	}
+
+	subjectISDAS := strings.Split(IA, "-")
+	TRCid, err = strconv.ParseInt(subjectISDAS[0], 10, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("certificate subject does not have a valid IA: "+
+			"expected: %s, actual: %s, err=%w", "ISD-AS", IA, err)
+	}
+	return
+}
+
+// getTRCsByISDid returns all the TRCs for a specific ISD ID.
 func getTRCsByISDid(outputPath string, isdID int64) ([]trcFileSummary, error) {
 	trcs, err := os.ReadDir(path.Join(outputPath, "certs"))
 	if err != nil {
@@ -209,22 +272,22 @@ func getTRCsByISDid(outputPath string, isdID int64) ([]trcFileSummary, error) {
 		filePath := path.Join(outputPath, "certs", trcName.Name())
 		v, err := os.ReadFile(filePath)
 		if err != nil {
-			log.Error("reading TRC file %s failed: %w", filePath, err)
+			log.Error("reading TRC file failed", "path", filePath, "err", err)
 			continue
 		}
-		var trc trcSummary
-		_, err = asn1.Unmarshal(v, &trc)
+		trc, err := getTRCSummary(v)
 		if err != nil {
-			log.Error("parsing TRC file %s failed: %w", filePath, err)
+			log.Error("parsing TRC file failed", "path", filePath, "err", err)
 			continue
 		}
 		if trc.ID.ISD == isdID {
-			isdTRCs = append(isdTRCs, trcFileSummary{trc: trc, path: filePath})
+			isdTRCs = append(isdTRCs, trcFileSummary{trc: *trc, path: filePath})
 		}
 	}
-	return isdTRCs, nil
+	return isdTRCs, err
 }
 
+// sortTRCsFiles sorts the TRC summaries according to their update chain order.
 func sortTRCsFiles(trcFileSummaries []trcFileSummary) (trcUpdateChain sortedTRCFileSummaries) {
 	// sort from lowest TRC ISD ID, base number and serial number to highest, in that order
 	sort.Sort(sortedTRCFileSummaries(trcFileSummaries))
@@ -232,67 +295,15 @@ func sortTRCsFiles(trcFileSummaries []trcFileSummary) (trcUpdateChain sortedTRCF
 }
 
 func verifySignature(outputPath, workingDir string) error {
-	signedTopologyPath := path.Join(workingDir, signedTopologyFileName)
-
-	timestamp := time.Now().Unix()
 	// Wipe old temporary directories, except last 10
 	err := cleanupVerifyDirs(workingDir)
 	if err != nil {
 		log.Info("Unable to remove old verify directories", "err", err)
 	}
-	// Create verify directory
-	bootstrapperPath := path.Join(workingDir, fmt.Sprintf("verify-%d", timestamp))
-	err = os.Mkdir(bootstrapperPath, 0775)
-	if err != nil {
-		return fmt.Errorf("failed to create verify directory: dir: %s, err: %w", bootstrapperPath, err)
-	}
 
-	// extract unverified payload
-	unverifiedTopologyPath := path.Join(bootstrapperPath, topologyJSONFileName+".unverified")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	err = opensslCMSNoVerifyOutput(ctx, signedTopologyPath, unverifiedTopologyPath)
+	err = verifyTopologySignature(outputPath, workingDir)
 	if err != nil {
-		return fmt.Errorf("extracting unverified payload failed: %w", err)
-	}
-
-	unverifiedTopo, err := os.ReadFile(unverifiedTopologyPath)
-	if err != nil {
-		return fmt.Errorf("reading unverified payload failed: %w", err)
-	}
-	topoIA := topoIA{}
-	err = json.Unmarshal(unverifiedTopo, &topoIA)
-	if err != nil {
-		return fmt.Errorf("parsing unverified payload failed: %w", err)
-	}
-	ids := strings.Split(topoIA.IA, "-")
-	trcID, err := strconv.ParseInt(ids[0], 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid ISD id: topology: %s, err: %w", unverifiedTopologyPath, err)
-	}
-
-	trcs, err := getTRCsByISDid(outputPath, trcID)
-	if err != nil {
-		return err
-	}
-	if len(trcs) == 0 {
-		return fmt.Errorf("unable to verify signature, no valid TRC found in %s,  ISD id: %d", outputPath, trcID)
-	}
-
-	verifiedTopologyPath := path.Join(outputPath, topologyJSONFileName)
-	unverifiedIA := topoIA.IA
-	// Check against TRC with highest base and serial number,
-	// as well the second highest serial number (while in the grace period)
-	sortedTRCsPaths := sortTRCsFiles(trcs).Paths()
-	for i := len(sortedTRCsPaths) - 1; i > 0 && i > len(sortedTRCsPaths)-1-2; i-- {
-		// Try to verify signature against the two latest TRCs matching the ISD claimed by the topology.
-		// TRC validity (expiration and grace period) is checked by the call to `scion-pki`.
-		// The signer AS needs to match the unverifiedIA claimed by the topology.
-		err = verifyTopologySignature(outputPath, unverifiedIA,
-			signedTopologyPath, verifiedTopologyPath, sortedTRCsPaths[i:])
-		if err == nil {
-			break
-		}
+		return fmt.Errorf("signature verification failed: %w", err)
 	}
 	return err
 }
@@ -322,6 +333,40 @@ func cleanupVerifyDirs(workingDir string) error {
 	return nil
 }
 
+// getTRCSummary returns the trcSummary with ISD, serial and base number information for a pem encoded or TRC blob.
+func getTRCSummary(rawTRC []byte) (*trcSummary, error) {
+	trcPem, _ := pem.Decode(rawTRC)
+	if trcPem != nil && trcPem.Type == "TRC" {
+		rawTRC = trcPem.Bytes
+	}
+	var rawTRCSigned trcContainer
+	_, err := asn1.Unmarshal(rawTRC, &rawTRCSigned)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse trc container: %w", err)
+	}
+
+	if !rawTRCSigned.ContentType.Equal(asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 7, 2}) {
+		return nil, fmt.Errorf("wrong trc signed data content type")
+	}
+	var trcSignedData trcSignedData
+	_, err = asn1.Unmarshal(rawTRCSigned.Content.Bytes, &trcSignedData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse trc signed data: %w", err)
+	}
+	var trcContent asn1.RawValue
+	_, err = asn1.Unmarshal(trcSignedData.EncapContentInfo.EContent.Bytes, &trcContent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse trc encap content data: %w", err)
+	}
+
+	var trcSummary trcSummary
+	_, err = asn1.Unmarshal(trcContent.Bytes, &trcSummary)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TRC ID failed: %w", err)
+	}
+	return &trcSummary, nil
+}
+
 type trcFileSummary struct {
 	trc  trcSummary
 	path string
@@ -335,7 +380,6 @@ func (s sortedTRCFileSummaries) Len() int {
 
 func (s sortedTRCFileSummaries) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
-	return
 }
 
 func (s sortedTRCFileSummaries) Less(i, j int) bool {
@@ -369,5 +413,22 @@ type asn1ID struct {
 }
 
 type trcSummary struct {
-	ID asn1ID `asn1:"iD"`
+	Version int64  `asn1:"version"`
+	ID      asn1ID `asn1:"iD"`
+}
+
+type trcEncapsulatedContentInfo struct {
+	EContentType asn1.ObjectIdentifier
+	EContent     asn1.RawValue `asn1:"optional,explicit,tag:0"`
+}
+
+type trcSignedData struct {
+	Version          int
+	DigestAlgorithms []pkix.AlgorithmIdentifier `asn1:"set"`
+	EncapContentInfo trcEncapsulatedContentInfo
+}
+
+type trcContainer struct {
+	ContentType asn1.ObjectIdentifier
+	Content     asn1.RawValue `asn1:"explicit,tag:0"`
 }

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -182,14 +182,14 @@ var payload = `{
 
 func TestVerify(t *testing.T) {
 	tmpDir := path.Join(os.TempDir(), "bootstrapper-cppki-tests")
-	err := os.MkdirAll(tmpDir, 0777)
+	err := os.MkdirAll(tmpDir, 0775)
 	if err != nil {
 		log.Error("Failed to create test directory for testrun", "dir", tmpDir, "err", err)
 	}
 
 	// Generate signed payload
 	outputPath := path.Join(tmpDir, "sign")
-	err = os.Mkdir(outputPath, 0777)
+	err = os.Mkdir(outputPath, 0775)
 	if err != nil {
 		log.Error("Failed to create verify test directory for testrun", "dir", tmpDir, "err", err)
 	}
@@ -220,7 +220,7 @@ func TestVerify(t *testing.T) {
 
 	// Verify signed payload
 	outputPath = path.Join(tmpDir, "verify")
-	err = os.Mkdir(outputPath, 0777)
+	err = os.Mkdir(outputPath, 0775)
 	if err != nil {
 		log.Error("Failed to create verify test directory for testrun", "dir", tmpDir, "err", err)
 	}

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -253,7 +253,7 @@ func TestVerify(t *testing.T) {
 	verifiedTopologyPath := path.Join(outputPath, topologyJSONFileName)
 	// run the actual test, verifying the signature
 	// using the signed payload and the TRC, and the IA extracted from the topology
-	if err := verifyTopologySignature(outputPath, "17-ffaa:1:1", payloadPath, trcPath, verifiedTopologyPath);
+	if err := verifyTopologySignature(outputPath, "17-ffaa:1:1", payloadPath, verifiedTopologyPath, []string{trcPath});
 		err != nil {
 		log.Error("Signature verification failed: verifyTopologySignature", "err", err)
 		t.FailNow()

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -1,0 +1,217 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	log "github.com/inconshreveable/log15"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+)
+
+// reuse test vectors from SCIONLab:
+// https://github.com/netsec-ethz/scionlab/blob/develop/scionlab/tests/data/test_config_tar/
+
+var isd17B1S1trc = `-----BEGIN TRC-----
+MIIMDwYJKoZIhvcNAQcCoIIMADCCC/wCAQExDzANBglghkgBZQMEAgMFADCCCHMG
+CSqGSIb3DQEHAaCCCGQEgghgMIIIXAIBADAJAgERAgEBAgEBMCIYDzIwMjExMDA2
+MTIyNTUyWhgPMjAyMzEwMDYxMjI1NTFaAgEAAQEAMAACAQEwDRMLZmZhYTowOjEx
+MDEwDRMLZmZhYTowOjExMDEMF1NDSU9OTGFiIFRSQyBmb3IgSVNEIDE3MIIH5DCC
+ApEwggI3oAMCAQICFGZKDbQBJIsSYPrCclG8NkMH13qoMAoGCCqGSM49BAMEMIGl
+MQswCQYDVQQGEwJDSDELMAkGA1UECAwCWkgxEDAOBgNVBAcMB1rDvHJpY2gxDzAN
+BgNVBAoMBk5ldHNlYzEPMA0GA1UECwwGTmV0c2VjMTQwMgYDVQQDDCsxNy1mZmFh
+OjA6MTEwMSBTZW5zaXRpdmUgVm90aW5nIENlcnRpZmljYXRlMR8wHQYLKwYBBAGD
+sBwBAgEMDjE3LWZmYWE6MDoxMTAxMB4XDTIxMTAwNjEyMjU1MloXDTIzMTAwNjEy
+MjU1MlowgaUxCzAJBgNVBAYTAkNIMQswCQYDVQQIDAJaSDEQMA4GA1UEBwwHWsO8
+cmljaDEPMA0GA1UECgwGTmV0c2VjMQ8wDQYDVQQLDAZOZXRzZWMxNDAyBgNVBAMM
+KzE3LWZmYWE6MDoxMTAxIFNlbnNpdGl2ZSBWb3RpbmcgQ2VydGlmaWNhdGUxHzAd
+BgsrBgEEAYOwHAECAQwOMTctZmZhYTowOjExMDEwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATfYQ9Emz/hyjygE9Ijayr17V+cEakXPYeId0kaiMgSKoQ/9m3rF1Ql
+JaVumtrCiEsZSuPUyw7tVpewcvY+USi4o0MwQTAdBgNVHQ4EFgQUvt/0bWH4pg6W
+ywbu4ZvqIlOFaXgwIAYDVR0lBBkwFwYLKwYBBAGDsBwBAwEGCCsGAQUFBwMIMAoG
+CCqGSM49BAMEA0gAMEUCIQCB9H0vy4yChfuuKwWAg5l4JerJDzzp7HKjjSEKgyWQ
+BAIgXQKpYOQsalkxq5y3irO6UdbDZUnGhI3PtSwZwZ8fMc4wggKNMIICM6ADAgEC
+AhQsPo1qERfbrI4Zp40yJFV4qNxvMjAKBggqhkjOPQQDBDCBozELMAkGA1UEBhMC
+Q0gxCzAJBgNVBAgMAlpIMRAwDgYDVQQHDAdaw7xyaWNoMQ8wDQYDVQQKDAZOZXRz
+ZWMxDzANBgNVBAsMBk5ldHNlYzEyMDAGA1UEAwwpMTctZmZhYTowOjExMDEgUmVn
+dWxhciBWb3RpbmcgQ2VydGlmaWNhdGUxHzAdBgsrBgEEAYOwHAECAQwOMTctZmZh
+YTowOjExMDEwHhcNMjExMDA2MTIyNTUyWhcNMjMxMDA2MTIyNTUyWjCBozELMAkG
+A1UEBhMCQ0gxCzAJBgNVBAgMAlpIMRAwDgYDVQQHDAdaw7xyaWNoMQ8wDQYDVQQK
+DAZOZXRzZWMxDzANBgNVBAsMBk5ldHNlYzEyMDAGA1UEAwwpMTctZmZhYTowOjEx
+MDEgUmVndWxhciBWb3RpbmcgQ2VydGlmaWNhdGUxHzAdBgsrBgEEAYOwHAECAQwO
+MTctZmZhYTowOjExMDEwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASc/1eDIL/m
+redZbfXIhh2sTnzYJz00SF717wi5Jwf+vr5ljqtbbbIeVAyWJ8koV1ZbcSRqCLXy
+wYdLbEKHf65Do0MwQTAdBgNVHQ4EFgQU1RaF8vMPCZNRmsdF8LZOo7w6VwwwIAYD
+VR0lBBkwFwYLKwYBBAGDsBwBAwIGCCsGAQUFBwMIMAoGCCqGSM49BAMEA0gAMEUC
+IGqVOT/djhHdVvwnCU1hiHFEQwJsK+xxDDrJyC20+eqUAiEA/H+Fjc4j3FpB/67Q
+2UetL3pln4lLNV6Ddr3UfrGTipkwggK6MIICX6ADAgECAhQGPF2Qb3JrKsLtTv/O
+tnsQNL+BtjAKBggqhkjOPQQDBDCBpzELMAkGA1UEBhMCQ0gxCzAJBgNVBAgMAlpI
+MRAwDgYDVQQHDAdaw7xyaWNoMQ8wDQYDVQQKDAZOZXRzZWMxDzANBgNVBAsMBk5l
+dHNlYzE2MDQGA1UEAwwtMTctZmZhYTowOjExMDEgSGlnaCBTZWN1cml0eSBSb290
+IENlcnRpZmljYXRlMR8wHQYLKwYBBAGDsBwBAgEMDjE3LWZmYWE6MDoxMTAxMB4X
+DTIxMTAwNjEyMjU1MloXDTIzMTAwNjEyMjU1MlowgacxCzAJBgNVBAYTAkNIMQsw
+CQYDVQQIDAJaSDEQMA4GA1UEBwwHWsO8cmljaDEPMA0GA1UECgwGTmV0c2VjMQ8w
+DQYDVQQLDAZOZXRzZWMxNjA0BgNVBAMMLTE3LWZmYWE6MDoxMTAxIEhpZ2ggU2Vj
+dXJpdHkgUm9vdCBDZXJ0aWZpY2F0ZTEfMB0GCysGAQQBg7AcAQIBDA4xNy1mZmFh
+OjA6MTEwMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAWnZwUPtgWMWN+4+pyP
+lOj6lQxO3mwG4kId7OR6JivhzXhGrr0i5mu/Pk/OURbiE6tFtsQiiU1p3y3+6FvR
+1QyjZzBlMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYDVR0PAQH/BAQDAgEGMB0GA1Ud
+DgQWBBTgw3sBAs4Pv6enakjeGGtTbtRF0TAgBgNVHSUEGTAXBgsrBgEEAYOwHAED
+AwYIKwYBBQUHAwgwCgYIKoZIzj0EAwQDSQAwRgIhAIAcsrtsfkmmbdShQ9rC6hkC
+R6wXdhwbv8VaaN/e6P0CAiEAisapnWgBEnrMVKMORtHHsL5V2UgKGetHjn7ThPBQ
+M/0xggNtMIIBsQIBATCBvDCBozELMAkGA1UEBhMCQ0gxCzAJBgNVBAgMAlpIMRAw
+DgYDVQQHDAdaw7xyaWNoMQ8wDQYDVQQKDAZOZXRzZWMxDzANBgNVBAsMBk5ldHNl
+YzEyMDAGA1UEAwwpMTctZmZhYTowOjExMDEgUmVndWxhciBWb3RpbmcgQ2VydGlm
+aWNhdGUxHzAdBgsrBgEEAYOwHAECAQwOMTctZmZhYTowOjExMDECFCw+jWoRF9us
+jhmnjTIkVXio3G8yMA0GCWCGSAFlAwQCAwUAoIGJMBgGCSqGSIb3DQEJAzELBgkq
+hkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8XDTIxMTAwNjEyMjU1MlowTwYJKoZIhvcN
+AQkEMUIEQLqNciXLnXoglyCNndLw76BIAxyk5ERzykDVtfHu86AOeR0q+ium9edf
+RUv5BQkSBvdj9AJf7X8PMBSqiA3mgHAwCgYIKoZIzj0EAwQERjBEAiAOAXF2nU9z
+rlh6t6ARiwvC1xjRjOD7GvF+4rZjzp3mNQIgKu/3Kp7mDkRF5fvgMU9/6AKxi9ba
+w8SOi8RtJOPL+aowggG0AgEBMIG+MIGlMQswCQYDVQQGEwJDSDELMAkGA1UECAwC
+WkgxEDAOBgNVBAcMB1rDvHJpY2gxDzANBgNVBAoMBk5ldHNlYzEPMA0GA1UECwwG
+TmV0c2VjMTQwMgYDVQQDDCsxNy1mZmFhOjA6MTEwMSBTZW5zaXRpdmUgVm90aW5n
+IENlcnRpZmljYXRlMR8wHQYLKwYBBAGDsBwBAgEMDjE3LWZmYWE6MDoxMTAxAhRm
+Sg20ASSLEmD6wnJRvDZDB9d6qDANBglghkgBZQMEAgMFAKCBiTAYBgkqhkiG9w0B
+CQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3DQEJBTEPFw0yMTEwMDYxMjI1NTJaME8G
+CSqGSIb3DQEJBDFCBEC6jXIly516IJcgjZ3S8O+gSAMcpOREc8pA1bXx7vOgDnkd
+KvorpvXnX0VL+QUJEgb3Y/QCX+1/DzAUqogN5oBwMAoGCCqGSM49BAMEBEcwRQIh
+AId+90b54IZxMPxKvJVRzN+wDz6l92Rq6IfotDF7blAnAiAs8/ZNlxymdSehL/Sp
+VqSiHiMvXCXTvPPXPAys1b0EFw==
+-----END TRC-----`
+
+var isd17ASffaa_0_1101CAcrt = `-----BEGIN CERTIFICATE-----
+MIICsDCCAlWgAwIBAgIUT9QuzhrVR+1POaK2wWizNABrEGUwCgYIKoZIzj0EAwQw
+gacxCzAJBgNVBAYTAkNIMQswCQYDVQQIDAJaSDEQMA4GA1UEBwwHWsO8cmljaDEP
+MA0GA1UECgwGTmV0c2VjMQ8wDQYDVQQLDAZOZXRzZWMxNjA0BgNVBAMMLTE3LWZm
+YWE6MDoxMTAxIEhpZ2ggU2VjdXJpdHkgUm9vdCBDZXJ0aWZpY2F0ZTEfMB0GCysG
+AQQBg7AcAQIBDA4xNy1mZmFhOjA6MTEwMTAeFw0yMTEwMDYxMjI1NTJaFw0yMzEw
+MDYxMjI1NTJaMIGeMQswCQYDVQQGEwJDSDELMAkGA1UECAwCWkgxEDAOBgNVBAcM
+B1rDvHJpY2gxDzANBgNVBAoMBk5ldHNlYzEPMA0GA1UECwwGTmV0c2VjMS0wKwYD
+VQQDDCQxNy1mZmFhOjA6MTEwMSBTZWN1cmUgQ0EgQ2VydGlmaWNhdGUxHzAdBgsr
+BgEEAYOwHAECAQwOMTctZmZhYTowOjExMDEwWTATBgcqhkjOPQIBBggqhkjOPQMB
+BwNCAASKLMjlvW15Q5MHamAEQZ/EtbDKV6N58IkBvBPGJ2faCCGr4h+sW8iUW3tw
+ie6J+y84O+1sL2uZAbsTVRYCtUL3o2YwZDASBgNVHRMBAf8ECDAGAQH/AgEAMA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUNNYmuhhGSEw+qIDlgMMEGQ5P7i4wHwYD
+VR0jBBgwFoAU4MN7AQLOD7+np2pI3hhrU27URdEwCgYIKoZIzj0EAwQDSQAwRgIh
+AIyt8UTBKTWCQZciUWqUhZfJsJrXKeuPtIjFt8lQGPGjAiEAtJpFS3b3Czyn3FN8
+3RxiFr644HOEhrsTA5tcBnTM5Fg=
+-----END CERTIFICATE-----`
+
+var isd17ASffaa_1_1aspem = `-----BEGIN CERTIFICATE-----
+MIICrjCCAlSgAwIBAgIUQD+itCyOkKJwAPTOY6Zh8GpruQ0wCgYIKoZIzj0EAwQw
+gZ4xCzAJBgNVBAYTAkNIMQswCQYDVQQIDAJaSDEQMA4GA1UEBwwHWsO8cmljaDEP
+MA0GA1UECgwGTmV0c2VjMQ8wDQYDVQQLDAZOZXRzZWMxLTArBgNVBAMMJDE3LWZm
+YWE6MDoxMTAxIFNlY3VyZSBDQSBDZXJ0aWZpY2F0ZTEfMB0GCysGAQQBg7AcAQIB
+DA4xNy1mZmFhOjA6MTEwMTAeFw0yMTEwMDYxMjI1NTRaFw0yMjEwMDYxMjI1NTRa
+MIGRMQswCQYDVQQGEwJDSDELMAkGA1UECAwCWkgxEDAOBgNVBAcMB1rDvHJpY2gx
+DzANBgNVBAoMBk5ldHNlYzEPMA0GA1UECwwGTmV0c2VjMSMwIQYDVQQDDBoxNy1m
+ZmFhOjE6MSBBUyBDZXJ0aWZpY2F0ZTEcMBoGCysGAQQBg7AcAQIBDAsxNy1mZmFh
+OjE6MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABH9Ai13zQwdebPFEPoVxuRJ2
+A8s9Q/oM+K0nBmUPjFPhPRjGExUIZS146b/wkDPfOrH6WgMmjBAjrAS+Tif88lCj
+ezB5MA4GA1UdDwEB/wQEAwIHgDAdBgNVHQ4EFgQUOpKlpPIl37u4sXKLzXH+OteO
+ovYwHwYDVR0jBBgwFoAUNNYmuhhGSEw+qIDlgMMEGQ5P7i4wJwYDVR0lBCAwHgYI
+KwYBBQUHAwEGCCsGAQUFBwMCBggrBgEFBQcDCDAKBggqhkjOPQQDBANIADBFAiEA
+1YErvCqXixVjcERpummNCZhwVeta8hYhIpdJNqctgqgCIEQdyQeZmYWFIBC30dV3
+x/qeYi8mVb5pxB/E2LRrBDE0
+-----END CERTIFICATE-----
+`
+
+var isd17ASffaa_1_1cpASkey = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgXxoGe3zZJinUpIlu
+BoOsiiIP6du8N9hEQNeKckjLVw6hRANCAAR/QItd80MHXmzxRD6FcbkSdgPLPUP6
+DPitJwZlD4xT4T0YxhMVCGUteOm/8JAz3zqx+loDJowQI6wEvk4n/PJQ
+-----END PRIVATE KEY-----`
+
+var payload = `TEST payload`
+
+func TestVerify(t *testing.T) {
+	tmpDir := path.Join(os.TempDir(), "bootstrapper-cppki-tests")
+	err := os.MkdirAll(tmpDir, 0777)
+	if err != nil {
+		log.Error("Failed to create test directory for testrun", "dir", tmpDir, "err", err)
+	}
+
+	// Generate signed payload
+	outputPath := path.Join(tmpDir, "sign")
+	err = os.Mkdir(outputPath, 0777)
+	if err != nil {
+		log.Error("Failed to create verify test directory for testrun", "dir", tmpDir, "err", err)
+	}
+	// Dump files payload, isd17ASffaa_0_1101CAcrt, isd17ASffaa_1_1aspem, isd17ASffaa_1_1cpASkey to directory sign
+	files := map[string]string{
+		"payload": payload,
+		"ISD17-ASffaa_0_1101.ca.crt": isd17ASffaa_0_1101CAcrt,
+		"ISD17-ASffaa_1_1.as.pem": isd17ASffaa_1_1aspem,
+		"ISD17-ASffaa_1_1.cp.as.key": isd17ASffaa_1_1cpASkey}
+	for fileName, fileContent := range files {
+		filePath := path.Join(outputPath, fileName)
+		err = os.WriteFile(filePath, []byte(fileContent), 0666)
+		if err != nil {
+			log.Error("Failed writing files required for signing", "outputPath", outputPath, "err", err)
+		}
+	}
+	payloadPath := path.Join(outputPath, "payload")
+	signedPayloadPath := path.Join(outputPath, "payload.signed")
+	asKeyPath := path.Join(outputPath, "ISD17-ASffaa_1_1.cp.as.key")
+	asCertPath := path.Join(outputPath, "ISD17-ASffaa_1_1.as.pem")
+	caCertPath := path.Join(outputPath, "ISD17-ASffaa_0_1101.ca.crt")
+	err = exec.Command( "openssl", "cms", "-sign", "-text",
+		"-in", payloadPath, "-out", signedPayloadPath, "-inkey", asKeyPath,
+		"-signer", asCertPath, "-certfile", caCertPath).Run()
+	if err != nil {
+		log.Error("Failed create signed file", "outputPath", outputPath, "err", err)
+	}
+
+	// Verify signed payload
+	outputPath = path.Join(tmpDir, "verify")
+	err = os.Mkdir(outputPath, 0777)
+	if err != nil {
+		log.Error("Failed to create verify test directory for testrun", "dir", tmpDir, "err", err)
+	}
+	// copy payload.signed and dump isd17sB1S1trc to directory verify
+	signedPayload, err := os.Open(signedPayloadPath)
+	if err != nil {
+		log.Error("Failed copying signed payload", "err", err)
+	}
+	defer signedPayload.Close()
+	payloadPath = path.Join(outputPath, "payload.signed")
+	payloadFile, err := os.Create(payloadPath)
+	if err != nil {
+		log.Error("Failed copying signed payload", "err", err)
+	}
+	defer payloadFile.Close()
+	_, err = io.Copy(payloadFile, signedPayload)
+	if err != nil {
+		log.Error("Failed copying signed payload", "err", err)
+	}
+	err = payloadFile.Sync()
+	if err != nil {
+		log.Error("Failed copying signed payload", "err", err)
+	}
+	trcPath := path.Join(outputPath, "ISD17-B1-S1.trc")
+	err = os.WriteFile(trcPath, []byte(isd17B1S1trc), 0666)
+	if err != nil {
+		log.Error("Failed writing TRC file", "err", err)
+	}
+
+	// run the actual test, verifying the signature using only the signed payload and the TRC
+	if err := verifyTopologySignature(outputPath, payloadPath, trcPath); err != nil {
+		log.Error("Signature verification failed: verifyTopologySignature", "err", err)
+		t.FailNow()
+	}
+}

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -19,7 +19,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -187,7 +187,7 @@ func TestVerify(t *testing.T) {
 	}
 
 	// Generate signed payload
-	signPath := path.Join(tmpDir, "sign")
+	signPath := filepath.Join(tmpDir, "sign")
 	err = os.MkdirAll(signPath, 0775)
 	if err != nil {
 		log.Error("Failed to create sign test directory for testrun", "dir", signPath, "err", err)
@@ -199,17 +199,17 @@ func TestVerify(t *testing.T) {
 		"ISD17-ASffaa_1_1.as.pem":    isd17ASffaa_1_1aspem,
 		"ISD17-ASffaa_1_1.cp.as.key": isd17ASffaa_1_1cpASkey}
 	for fileName, fileContent := range files {
-		filePath := path.Join(signPath, fileName)
+		filePath := filepath.Join(signPath, fileName)
 		err = os.WriteFile(filePath, []byte(fileContent), 0666)
 		if err != nil {
 			log.Error("Failed writing files required for signing", "signPath", signPath, "err", err)
 		}
 	}
-	payloadPath := path.Join(signPath, "payload")
-	signedPayloadPath := path.Join(signPath, "payload.signed")
-	asKeyPath := path.Join(signPath, "ISD17-ASffaa_1_1.cp.as.key")
-	asCertPath := path.Join(signPath, "ISD17-ASffaa_1_1.as.pem")
-	caCertPath := path.Join(signPath, "ISD17-ASffaa_0_1101.ca.crt")
+	payloadPath := filepath.Join(signPath, "payload")
+	signedPayloadPath := filepath.Join(signPath, "payload.signed")
+	asKeyPath := filepath.Join(signPath, "ISD17-ASffaa_1_1.cp.as.key")
+	asCertPath := filepath.Join(signPath, "ISD17-ASffaa_1_1.as.pem")
+	caCertPath := filepath.Join(signPath, "ISD17-ASffaa_0_1101.ca.crt")
 	err = exec.Command("openssl", "cms", "-sign", "-text",
 		"-in", payloadPath, "-out", signedPayloadPath, "-inkey", asKeyPath,
 		"-signer", asCertPath, "-certfile", caCertPath).Run()
@@ -218,7 +218,7 @@ func TestVerify(t *testing.T) {
 	}
 
 	// Verify signed payload
-	bootstrapperPath := path.Join(tmpDir, "bootstrapper")
+	bootstrapperPath := filepath.Join(tmpDir, "bootstrapper")
 	err = os.MkdirAll(bootstrapperPath, 0775)
 	if err != nil {
 		log.Error("Failed to create bootstrapper test directory for testrun",
@@ -230,7 +230,7 @@ func TestVerify(t *testing.T) {
 		log.Error("Failed copying signed payload", "err", err)
 	}
 	defer signedPayload.Close()
-	payloadPath = path.Join(bootstrapperPath, "topology.signed")
+	payloadPath = filepath.Join(bootstrapperPath, "topology.signed")
 	payloadFile, err := os.Create(payloadPath)
 	if err != nil {
 		log.Error("Failed copying signed payload", "err", err)
@@ -244,12 +244,12 @@ func TestVerify(t *testing.T) {
 	if err != nil {
 		log.Error("Failed copying signed payload", "err", err)
 	}
-	trcsPath := path.Join(tmpDir, "certs")
+	trcsPath := filepath.Join(tmpDir, "certs")
 	err = os.MkdirAll(trcsPath, 0775)
 	if err != nil {
 		log.Error("Failed to create certs test directory for testrun", "dir", tmpDir, "err", err)
 	}
-	trcPath := path.Join(trcsPath, "ISD17-B1-S1.trc")
+	trcPath := filepath.Join(trcsPath, "ISD17-B1-S1.trc")
 	err = os.WriteFile(trcPath, []byte(isd17B1S1trc), 0666)
 	if err != nil {
 		log.Error("Failed writing TRC file", "err", err)

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -137,7 +137,48 @@ BoOsiiIP6du8N9hEQNeKckjLVw6hRANCAAR/QItd80MHXmzxRD6FcbkSdgPLPUP6
 DPitJwZlD4xT4T0YxhMVCGUteOm/8JAz3zqx+loDJowQI6wEvk4n/PJQ
 -----END PRIVATE KEY-----`
 
-var payload = `TEST payload`
+var payload = `{
+  "attributes": [],
+  "border_routers": {
+    "br-1": {
+      "interfaces": {
+        "1": {
+          "isd_as": "17-ffaa:0:1107",
+          "link_to": "PARENT",
+          "mtu": 1472,
+          "underlay": {
+            "public": "10.0.0.1:54321",
+            "remote": "10.0.8.1:50001"
+          }
+        }
+      },
+      "internal_addr": "127.0.0.1:30001"
+    }
+  },
+  "colibri_service": {
+    "co-1": {
+      "addr": "127.0.0.1:30257"
+    }
+  },
+  "control_service": {
+    "cs-1": {
+      "addr": "127.0.0.1:30254"
+    }
+  },
+  "discovery_service": {
+    "ds-1": {
+      "addr": "127.0.0.1:30254"
+    }
+  },
+  "isd_as": "17-ffaa:1:1",
+  "mtu": 1472,
+  "sigs": {
+    "sig-1": {
+      "ctrl_addr": "127.0.0.1:30256",
+      "data_addr": "127.0.0.1:30056"
+    }
+  }
+}`
 
 func TestVerify(t *testing.T) {
 	tmpDir := path.Join(os.TempDir(), "bootstrapper-cppki-tests")

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -195,9 +195,9 @@ func TestVerify(t *testing.T) {
 	}
 	// Dump files payload, isd17ASffaa_0_1101CAcrt, isd17ASffaa_1_1aspem, isd17ASffaa_1_1cpASkey to directory sign
 	files := map[string]string{
-		"payload": payload,
+		"payload":                    payload,
 		"ISD17-ASffaa_0_1101.ca.crt": isd17ASffaa_0_1101CAcrt,
-		"ISD17-ASffaa_1_1.as.pem": isd17ASffaa_1_1aspem,
+		"ISD17-ASffaa_1_1.as.pem":    isd17ASffaa_1_1aspem,
 		"ISD17-ASffaa_1_1.cp.as.key": isd17ASffaa_1_1cpASkey}
 	for fileName, fileContent := range files {
 		filePath := path.Join(outputPath, fileName)
@@ -211,7 +211,7 @@ func TestVerify(t *testing.T) {
 	asKeyPath := path.Join(outputPath, "ISD17-ASffaa_1_1.cp.as.key")
 	asCertPath := path.Join(outputPath, "ISD17-ASffaa_1_1.as.pem")
 	caCertPath := path.Join(outputPath, "ISD17-ASffaa_0_1101.ca.crt")
-	err = exec.Command( "openssl", "cms", "-sign", "-text",
+	err = exec.Command("openssl", "cms", "-sign", "-text",
 		"-in", payloadPath, "-out", signedPayloadPath, "-inkey", asKeyPath,
 		"-signer", asCertPath, "-certfile", caCertPath).Run()
 	if err != nil {
@@ -250,8 +250,11 @@ func TestVerify(t *testing.T) {
 		log.Error("Failed writing TRC file", "err", err)
 	}
 
-	// run the actual test, verifying the signature using only the signed payload and the TRC
-	if err := verifyTopologySignature(outputPath, payloadPath, trcPath); err != nil {
+	verifiedTopologyPath := path.Join(outputPath, topologyJSONFileName)
+	// run the actual test, verifying the signature
+	// using the signed payload and the TRC, and the IA extracted from the topology
+	if err := verifyTopologySignature(outputPath, "17-ffaa:1:1", payloadPath, trcPath, verifiedTopologyPath);
+		err != nil {
 		log.Error("Signature verification failed: verifyTopologySignature", "err", err)
 		t.FailNow()
 	}

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -77,7 +76,7 @@ func PullTopology(outputPath string, addr *net.TCPAddr) error {
 		return fmt.Errorf("unable to parse RWTopology from JSON bytes: %w", err)
 	}*/
 	topologyPath := path.Join(outputPath, topologyJSONFileName)
-	err = ioutil.WriteFile(topologyPath, raw, 0644)
+	err = os.WriteFile(topologyPath, raw, 0644)
 	if err != nil {
 		return fmt.Errorf("bootstrapper could not store topology: %w", err)
 	}
@@ -96,7 +95,7 @@ func PullSignedTopology(outputPath string, addr *net.TCPAddr) error {
 		return err
 	}
 	signedTopologyPath := path.Join(outputPath, signedTopologyFileName)
-	err = ioutil.WriteFile(signedTopologyPath, raw, 0644)
+	err = os.WriteFile(signedTopologyPath, raw, 0644)
 	if err != nil {
 		return fmt.Errorf("bootstrapper could not store topology signature: %w", err)
 	}
@@ -157,8 +156,8 @@ func PullTRC(outputPath string, addr *net.TCPAddr, trcID TRCID) error {
 	}
 	trcPath := path.Join(outputPath, "certs",
 		fmt.Sprintf("ISD%d-B%d-S%d.trc", trcID.Isd, trcID.BaseNumber, trcID.SerialNumber))
-	if _, err := os.Stat("trcPath"); os.IsNotExist(err) {
-		err = ioutil.WriteFile(trcPath, raw, 0644)
+	if _, err := os.Stat(trcPath); os.IsNotExist(err) {
+		err = os.WriteFile(trcPath, raw, 0644)
 		if err != nil {
 			return fmt.Errorf("bootstrapper could not store TRC: %w", err)
 		}
@@ -203,7 +202,7 @@ func fetchRawBytes(fileName string, url string) ([]byte, error) {
 			log.Error(fmt.Sprintf("Error closing the body of the %s response", fileName), "err", err)
 		}
 	}()
-	raw, err := ioutil.ReadAll(r)
+	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read from response body: %w", err)
 	}

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -28,6 +28,8 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/bootstrapper/config"
 	// "github.com/scionproto/scion/go/lib/topology"
 	// "github.com/scionproto/scion/go/pkg/cs/api"
 )
@@ -43,12 +45,12 @@ const (
 	httpRequestTimeout        = 2 * time.Second
 )
 
-func FetchConfiguration(outputPath string, insecure bool, addr *net.TCPAddr) error {
+func FetchConfiguration(outputPath string, securityMode config.SecurityMode, addr *net.TCPAddr) error {
 	err := PullTRCs(outputPath, addr)
 	if err != nil {
 		return err
 	}
-	if insecure {
+	if securityMode == config.Insecure {
 		err = PullTopology(outputPath, addr)
 	} else {
 		err = PullSignedTopology(outputPath, addr)
@@ -156,6 +158,8 @@ func PullTRC(outputPath string, addr *net.TCPAddr, trcID TRCID) error {
 	}
 	trcPath := path.Join(outputPath, "certs",
 		fmt.Sprintf("ISD%d-B%d-S%d.trc", trcID.Isd, trcID.BaseNumber, trcID.SerialNumber))
+	// TODO: do additional checks for security_mode permissive and strict to check TRC update chain
+	// TODO: mark TRCs downloaded in the insecure mode as such
 	if _, err := os.Stat(trcPath); os.IsNotExist(err) {
 		err = os.WriteFile(trcPath, raw, 0644)
 		if err != nil {

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -181,7 +181,7 @@ func wipeInsecureSymlinks(outputPath string) error {
 			return err
 		}
 		// ignore non-symlinks
-		if fInfo.Mode()&os.ModeSymlink != 1 {
+		if fInfo.Mode()&os.ModeType != os.ModeSymlink {
 			continue
 		}
 		// stat the symlink, check if it links to a TRC from the insecure mode
@@ -241,7 +241,7 @@ func PullTRC(outputPath, workingDir string, addr *net.TCPAddr, securityMode conf
 	}
 	if securityMode == config.Insecure {
 		// symlink the TRC fetched in insecure mode into the standard directory
-		err = os.Symlink(trcPath, tmpTRCpath)
+		err = os.Symlink(tmpTRCpath, trcPath)
 		if err != nil {
 			return fmt.Errorf("symlinking insecure TRC failed: %w", err)
 		}

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -47,7 +47,7 @@ const (
 	httpRequestTimeout     = 2 * time.Second
 )
 
-func FetchConfiguration(outputPath string, workingDir string, securityMode config.SecurityMode, addr *net.TCPAddr) error {
+func FetchConfiguration(outputPath, workingDir string, securityMode config.SecurityMode, addr *net.TCPAddr) error {
 	err := PullTRCs(outputPath, workingDir, addr, securityMode)
 	if err != nil {
 		return err

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -1,3 +1,17 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package fetcher
 
 import (
@@ -8,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"time"
 
@@ -19,41 +34,38 @@ import (
 )
 
 const (
-	baseURL              = ""
-	topologyEndpoint     = "topology"
-	trcsEndpoint         = "trcs"
-	trcBlobEndpoint      = "trcs/isd%d-b%d-s%d/blob"
-	topologyJSONFileName = "topology.json"
-	httpRequestTimeout   = 2 * time.Second
+	baseURL                   = ""
+	topologyEndpoint          = "topology"
+	signedTopologyEndpoint    = "topology.signed"
+	trcsEndpoint              = "trcs"
+	trcBlobEndpoint           = "trcs/isd%d-b%d-s%d/blob"
+	topologyJSONFileName      = "topology.json"
+	signedTopologyFileName    = "topology.signed"
+	httpRequestTimeout        = 2 * time.Second
 )
 
-func FetchConfiguration(outputPath string, addr *net.TCPAddr) error {
+func FetchConfiguration(outputPath string, insecure bool, addr *net.TCPAddr) error {
 	err := PullTRCs(outputPath, addr)
 	if err != nil {
 		return err
 	}
-	err = PullTopology(outputPath, addr)
+	if insecure {
+		err = PullTopology(outputPath, addr)
+	} else {
+		err = PullSignedTopology(outputPath, addr)
+		if err != nil {
+			return err
+		}
+		err = verifySignature(outputPath)
+	}
 	return err
 }
 
 func PullTopology(outputPath string, addr *net.TCPAddr) error {
 	url := buildTopologyURL(addr.IP, addr.Port)
-	log.Info("Fetching topology", "url", url)
-	ctx, cancelF := context.WithTimeout(context.Background(), httpRequestTimeout)
-	defer cancelF()
-	r, err := fetchHTTP(ctx, url)
+	raw, err := fetchRawBytes("topology", url)
 	if err != nil {
-		log.Error("Failed to fetch topology from "+url, "err", err)
 		return err
-	}
-	defer func() {
-		if err := r.Close(); err != nil {
-			log.Error("Error closing the body of the topology response", "err", err)
-		}
-	}()
-	raw, err := ioutil.ReadAll(r)
-	if err != nil {
-		return fmt.Errorf("unable to read from response body: %w", err)
 	}
 	// Check that the topology is valid json
 	if !json.Valid(raw) {
@@ -77,6 +89,25 @@ func buildTopologyURL(ip net.IP, port int) string {
 	return fmt.Sprintf("http://%s:%d/%s", ip, port, urlPath)
 }
 
+func PullSignedTopology(outputPath string, addr *net.TCPAddr) error {
+	url := buildSignedTopologyURL(addr.IP, addr.Port)
+	raw, err := fetchRawBytes("signed topology", url)
+	if err != nil {
+		return err
+	}
+	signedTopologyPath := path.Join(outputPath, signedTopologyFileName)
+	err = ioutil.WriteFile(signedTopologyPath, raw, 0644)
+	if err != nil {
+		return fmt.Errorf("bootstrapper could not store topology signature: %w", err)
+	}
+	return nil
+}
+
+func buildSignedTopologyURL(ip net.IP, port int) string {
+	urlPath := baseURL + signedTopologyEndpoint
+	return fmt.Sprintf("http://%s:%d/%s", ip, port, urlPath)
+}
+
 // API definition
 // github.com/scionproto/scion/spec/control/trust.yml
 
@@ -94,23 +125,9 @@ type TRCID struct {
 
 func PullTRCs(outputPath string, addr *net.TCPAddr) error {
 	url := buildTRCsURL(addr.IP, addr.Port)
-	log.Info("Fetching TRCs index", "url", url)
-	ctx, cancelF := context.WithTimeout(context.Background(), httpRequestTimeout)
-	defer cancelF()
-	r, err := fetchHTTP(ctx, url)
+	raw, err := fetchRawBytes("TRCs index", url)
 	if err != nil {
-		log.Error("Failed to fetch TRCs index from "+url, "err", err)
 		return err
-	}
-	// Close response reader and handle errors
-	defer func() {
-		if err := r.Close(); err != nil {
-			log.Error("Error closing the body of the TRCs response", "err", err)
-		}
-	}()
-	raw, err := ioutil.ReadAll(r)
-	if err != nil {
-		return fmt.Errorf("unable to read from response body: %w", err)
 	}
 	// Get TRC identifiers
 	trcs := []TRCBrief{}
@@ -134,28 +151,19 @@ func buildTRCsURL(ip net.IP, port int) string {
 
 func PullTRC(outputPath string, addr *net.TCPAddr, trcID TRCID) error {
 	url := buildTRCURL(addr.IP, addr.Port, trcID)
-	log.Info("Fetching TRC", "url", url)
-	ctx, cancelF := context.WithTimeout(context.Background(), httpRequestTimeout)
-	defer cancelF()
-	r, err := fetchHTTP(ctx, url)
+	raw, err := fetchRawBytes("TRC", url)
 	if err != nil {
-		log.Error("Failed to fetch TRC from "+url, "err", err)
 		return err
-	}
-	defer func() {
-		if err := r.Close(); err != nil {
-			log.Error("Error closing the body of the TRC response", "err", err)
-		}
-	}()
-	raw, err := ioutil.ReadAll(r)
-	if err != nil {
-		return fmt.Errorf("unable to read from response body: %w", err)
 	}
 	trcPath := path.Join(outputPath, "certs",
 		fmt.Sprintf("ISD%d-B%d-S%d.trc", trcID.Isd, trcID.BaseNumber, trcID.SerialNumber))
-	err = ioutil.WriteFile(trcPath, raw, 0644)
-	if err != nil {
-		return fmt.Errorf("bootstrapper could not store TRC: %w", err)
+	if _, err := os.Stat("trcPath"); os.IsNotExist(err) {
+		err = ioutil.WriteFile(trcPath, raw, 0644)
+		if err != nil {
+			return fmt.Errorf("bootstrapper could not store TRC: %w", err)
+		}
+	} else {
+		log.Debug("Identical TRC version already exists, not overwritting.", "trcPath", trcPath)
 	}
 	return nil
 }
@@ -178,4 +186,26 @@ func fetchHTTP(ctx context.Context, url string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("status not OK: %w", fmt.Errorf("status: %s", res.Status))
 	}
 	return res.Body, nil
+}
+
+func fetchRawBytes(fileName string, url string) ([]byte, error) {
+	log.Info(fmt.Sprintf("Fetching %s", fileName), "url", url)
+	ctx, cancelF := context.WithTimeout(context.Background(), httpRequestTimeout)
+	defer cancelF()
+	r, err := fetchHTTP(ctx, url)
+	if err != nil {
+		log.Error(fmt.Sprintf("Failed to fetch %s from %s", fileName, url), "err", err)
+		return nil, err
+	}
+	// Close response reader and handle errors
+	defer func() {
+		if err := r.Close(); err != nil {
+			log.Error(fmt.Sprintf("Error closing the body of the %s response", fileName), "err", err)
+		}
+	}()
+	raw, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read from response body: %w", err)
+	}
+	return raw, nil
 }

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -37,14 +37,14 @@ import (
 )
 
 const (
-	baseURL                   = ""
-	topologyEndpoint          = "topology"
-	signedTopologyEndpoint    = "topology.signed"
-	trcsEndpoint              = "trcs"
-	trcBlobEndpoint           = "trcs/isd%d-b%d-s%d/blob"
-	topologyJSONFileName      = "topology.json"
-	signedTopologyFileName    = "topology.signed"
-	httpRequestTimeout        = 2 * time.Second
+	baseURL                = ""
+	topologyEndpoint       = "topology"
+	signedTopologyEndpoint = "topology.signed"
+	trcsEndpoint           = "trcs"
+	trcBlobEndpoint        = "trcs/isd%d-b%d-s%d/blob"
+	topologyJSONFileName   = "topology.json"
+	signedTopologyFileName = "topology.signed"
+	httpRequestTimeout     = 2 * time.Second
 )
 
 func FetchConfiguration(outputPath string, workingDir string, securityMode config.SecurityMode, addr *net.TCPAddr) error {
@@ -180,7 +180,7 @@ func wipeInsecureSymlinks(outputPath string) error {
 			return err
 		}
 		// ignore non-symlinks
-		if fInfo.Mode() & os.ModeSymlink != 1 {
+		if fInfo.Mode()&os.ModeSymlink != 1 {
 			continue
 		}
 		// stat the symlink, check if it links to a TRC from the insecure mode
@@ -237,7 +237,7 @@ func PullTRC(outputPath, workingDir string, addr *net.TCPAddr, securityMode conf
 	}
 	if securityMode == config.Insecure {
 		// symlink the TRC fetched in insecure mode into the standard directory
-		err = os.Symlink(trcPath,  tmpTRCpath)
+		err = os.Symlink(trcPath, tmpTRCpath)
 		if err != nil {
 			return fmt.Errorf("symlinking insecure TRC failed: %w", err)
 		}

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -145,11 +145,6 @@ func PullTRCs(outputPath string, addr *net.TCPAddr, securityMode config.Security
 		if err != nil {
 			log.Warn("Unable to remove symlinks to insecure TRCs", "err", err)
 		}
-		// Wipe old temporary directories, except last 10
-		err = cleanupVerifyDirs(outputPath)
-		if err != nil {
-			log.Info("Unable to remove old verify directories", "err", err)
-		}
 	}
 
 	// Sort TRCBriefs by ISD, serial and BaseNumber, to enable verifying the TRC update chain after each pull
@@ -202,11 +197,6 @@ func wipeInsecureSymlinks(outputPath string) error {
 		}
 	}
 	return nil
-}
-
-func cleanupVerifyDirs(outputPath string) error {
-	// TODO: do verify dir cleanup
-	return fmt.Errorf("not implemented, not cleaning up %s/verify-* directories", outputPath)
 }
 
 func PullTRC(outputPath string, addr *net.TCPAddr, securityMode config.SecurityMode, trcID TRCID) error {

--- a/fetcher/scion_openapi_test.go
+++ b/fetcher/scion_openapi_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+	log "github.com/inconshreveable/log15"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWipeInsecureSymlinks(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "bootstrapper-openapi-tests_*")
+	if err != nil {
+		log.Error("Failed to create test directory for testrun", "dir", tmpDir, "err", err)
+		return
+	}
+
+	certsDir := filepath.Join(tmpDir, "certs")
+	if err = os.Mkdir(certsDir, 0775); err != nil {
+		log.Error("Failed to create certs directory for testrun", "err", err)
+		return
+	}
+
+	for _, f := range []string{"ISD42-B2-S3.trc", "ISD7-B5-S2.trc"} {
+		if _, err := os.Create(filepath.Join(certsDir, f)); err != nil {
+			log.Error("Failed to create test files for testrun", "err", err)
+			return
+		}
+	}
+
+	workingDir := filepath.Join(tmpDir, "bootstrapper")
+	if err = os.Mkdir(workingDir, 0775); err != nil {
+		log.Error("Failed to create bootstrapper directory for testrun", "err", err)
+		return
+	}
+
+	trcsFromInsecureMode := []string{"ISD42-B2-S4.trc.insecure", "ISD7-B5-S1.trc.insecure"}
+	for _, f := range trcsFromInsecureMode {
+		if _, err := os.Create(filepath.Join(workingDir, f)); err != nil {
+			log.Error("Failed to create test files for testrun", "err", err)
+			return
+		}
+		err = os.Symlink(filepath.Join(workingDir, f), filepath.Join(certsDir, f))
+		if err != nil {
+			log.Error("Failed to symlink insecure TRC", "err", err)
+			return
+		}
+	}
+
+	// delete one of the TRC files from the insecure mode, get a dangling symlink
+	if err = os.Remove(filepath.Join(workingDir, trcsFromInsecureMode[0])); err != nil {
+		log.Error("Failed to remove insecure TRC", "err", err)
+		return
+	}
+
+	// run the actual test, verifying that wiping symlinks from the insecure mode works
+	if err = wipeInsecureSymlinks(tmpDir); err != nil {
+		log.Error("Failed to wipe symlinks: wipeInsecureSymlinks", "err", err)
+		t.FailNow()
+	}
+
+	// check that the TRC symlinks have been removed
+	trcs, err := os.ReadDir(filepath.Join(tmpDir, "certs"))
+	for _, trc := range trcs {
+		fInfo, err := trc.Info()
+		if err != nil {
+			log.Error("Failed to get file info", "err", err)
+		}
+		if fInfo.Mode().IsRegular() {
+			continue
+		}
+		if fInfo.Mode()&os.ModeSymlink != 1 {
+			log.Error("Not all insecure TRC symlinks removed",
+				"file", filepath.Join(tmpDir, "certs", trc.Name()))
+			t.FailNow()
+		}
+	}
+}

--- a/fetcher/scion_pki_tool_cmds.go
+++ b/fetcher/scion_pki_tool_cmds.go
@@ -1,0 +1,28 @@
+package fetcher
+
+import (
+	"context"
+	"os/exec"
+)
+
+// scion-pki commands
+
+// spkiTRCExtractCerts extracts the certificates contained in the TRC trustAnchorTRC into rootCertsBundlePath.
+func spkiTRCExtractCerts(ctx context.Context, trustAnchorTRC, rootCertsBundlePath string) error {
+	return exec.CommandContext(ctx, "scion-pki", "trc", "extract", "certificates",
+		trustAnchorTRC, "-o", rootCertsBundlePath).Run()
+}
+
+// spkiCertVerify verifies the AS certificate asCertChainPath against the sorted TRC update chain trcs.
+func spkiCertVerify(ctx context.Context, trcs, asCertChainPath string) error {
+	return exec.CommandContext(ctx, "scion-pki", "certificate", "verify",
+		"--trc", trcs, asCertChainPath).Run()
+}
+
+// spkiTRCVerify verifies the TRC update chain for candidateTRCPath anchored in the TRCs trcUpdateChainPaths
+func spkiTRCVerify(ctx context.Context, trcUpdateChainPaths []string, candidateTRCPath string) error {
+	cmdArgs := []string{"trc", "-verify", "--anchor"}
+	cmdArgs = append(cmdArgs, trcUpdateChainPaths...)
+	cmdArgs = append(cmdArgs, candidateTRCPath)
+	return exec.CommandContext(ctx, "scion-pki",  cmdArgs...).Run()
+}

--- a/fetcher/scion_pki_tool_cmds.go
+++ b/fetcher/scion_pki_tool_cmds.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"os/exec"
+	"strings"
 )
 
 // scion-pki commands
@@ -13,16 +14,17 @@ func spkiTRCExtractCerts(ctx context.Context, trustAnchorTRC, rootCertsBundlePat
 		trustAnchorTRC, "-o", rootCertsBundlePath).Run()
 }
 
-// spkiCertVerify verifies the AS certificate asCertChainPath against the sorted TRC update chain trcs.
-func spkiCertVerify(ctx context.Context, trcs, asCertChainPath string) error {
+// spkiCertVerify verifies the AS certificate asCertChainPath
+// against the sorted TRCs in the update chain trcsUpdateChain.
+func spkiCertVerify(ctx context.Context, trcsUpdateChain []string, asCertChainPath string) error {
 	return exec.CommandContext(ctx, "scion-pki", "certificate", "verify",
-		"--trc", trcs, asCertChainPath).Run()
+		"--trc", strings.Join(trcsUpdateChain, ","), asCertChainPath).Run()
 }
 
 // spkiTRCVerify verifies the TRC update chain for candidateTRCPath anchored in the TRCs trcUpdateChainPaths
-func spkiTRCVerify(ctx context.Context, trcUpdateChainPaths []string, candidateTRCPath string) error {
-	cmdArgs := []string{"trc", "-verify", "--anchor"}
-	cmdArgs = append(cmdArgs, trcUpdateChainPaths...)
-	cmdArgs = append(cmdArgs, candidateTRCPath)
-	return exec.CommandContext(ctx, "scion-pki",  cmdArgs...).Run()
+func spkiTRCVerify(ctx context.Context, trcAnchorPath string, updateChainCandidatePaths []string) error {
+	cmdArgs := []string{"trc", "verify", "--anchor"}
+	cmdArgs = append(cmdArgs, trcAnchorPath)
+	cmdArgs = append(cmdArgs, updateChainCandidatePaths...)
+	return exec.CommandContext(ctx, "scion-pki", cmdArgs...).Run()
 }

--- a/hinting/mdns.go
+++ b/hinting/mdns.go
@@ -17,7 +17,7 @@ package hinting
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"net"
 	"time"
@@ -52,7 +52,7 @@ func (g *MDNSSDHintGenerator) Generate(ipHintsChan chan<- net.TCPAddr) {
 	}
 	// library zeroconf is noisy by default and has no way to disable logging
 	stdlog.SetFlags(0)
-	stdlog.SetOutput(ioutil.Discard)
+	stdlog.SetOutput(io.Discard)
 	resolver, err := zeroconf.NewResolver(zeroconf.SelectIfaces([]net.Interface{*g.iface}))
 	if err != nil {
 		log.Error("mDNS could not construct dns resolver", "err", err)


### PR DESCRIPTION
Unless the insecure flag is set, download a TRC, a signed topology file and verify the signature.
Verifies the certificate chain of the included certificate against the TRC.
Crypto operations are only done using the tools scion-pki and openssl.