### PR TITLE
Add instructions for macOS and Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ package_rpm: build
 	bazel build //:scion-bootstrapper-rpm
 	cp bazel-bin/scion-bootstrapper-*.*.rpm bin/
 
+darwin:
+	@echo "Experimental"
+	env GOOS=darwin go build -o scion-bootstrapper -ldflags "-X github.com/netsec-ethz/bootstrapper/config.versionString="$(./.bazel-build-env | awk '{print $2}')
+
+windows:
+	@echo "Experimental"
+	env GOOS=windows go build -o scion-bootstrapper.exe -ldflags "-X github.com/netsec-ethz/bootstrapper/config.versionString="$(./.bazel-build-env | awk '{print $2}')
+
 define go_deps_boilerplate
 # Generated from go.mod by gazelle. DO NOT EDIT
 load("@bazel_gazelle//:deps.bzl", "go_repository")

--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@ It uses the following hinting mechanisms:
 - DHCPv6 `Vendor-specific Information Option` [RFC3315]
 - IPv6 NDP: DNS resolver and DNS Search List [RFC6106]
 - DNS-SRV: DNS service resource records [RFC2782]
+- DNS-NAPTR: Naming Authority Pointer DNS Resource Record [RFC2915]
 - DNS-SD: DNS service discovery [RFC6763]
 - mDNS: multicast DNS [RFC6762]
 
 It integrates with SCION by using the same OpenAPI as the control service uses
 for exposing TRCs (serving as root certificate) and the topology file
 (describing the local SCION topology).
+
+## Installing
+
+Install from the netsec package repository at `https://packages.netsec.inf.ethz.ch/debian`:
+`sudo apt-get install scion-bootstrapper`
 
 ## Building
 
@@ -24,6 +30,33 @@ The service files are in the `./res/packaging/debian/` directory.
 You can install Bazel by following the instructions at https://docs.bazel.build/versions/master/install-ubuntu.html
 You can then build the package by running `bazel build //:scion-bootstrapper-deb`.
 When contributing, please run `make all` in order to make sure that all targets build and to run the linter.
+
+Experimental availability is also provided for macOS and Windows. Run `make darwin` or `make windows` to build a
+Mach-O or PE32+ binary respectively.\
+---
+**NOTE**
+
+On macOS, you might need to remove the IPv6 address(es) from your network interface if IPv6 connectivity is broken.
+You can do so with the following command: `sudo networksetup -setv6off Ethernet`
+ (use the flag `-setv6automatic` to reenable).\
+On Windows, you might need to run the bootstrapper via the Command Prompt (cmd) instead of the PowerShell prompt.
+Symlinking the output directory on shares or as unprivileged user is also not supported.
+You can check your connection specific DNS suffix with `ipconfig` or
+ in the advanced DNS settings of the adapter properties.
+
+You might also need to explicitly allow the connections in your firewall, in particular for the broadcast based hinting
+mechanisms.
+
+---
+
+## Running
+
+The package starts the bootstrapper service at installation and adds a client hook to detect connectivity changes.\
+It can be manually restarted with `sudo systemctl restart 'scion-bootstrapper@*.service'`
+
+### Manual configuration
+Generate a default configuration with `./scion-bootstrapper -help-config > ./bootstrapper.yml`.\
+Run it with `./scion-bootstrapper -config bootstrapper.yml`.
 
 ## Client bootstrap service configuration
 

--- a/fetcher/scion_openapi.go
+++ b/fetcher/scion_openapi.go
@@ -138,6 +138,17 @@ func PullTRCs(outputPath, workingDir string, addr *net.TCPAddr, securityMode con
 	if err != nil {
 		return fmt.Errorf("unable to parse TRCs listing from JSON bytes: %w", err)
 	}
+	certDir := filepath.Join(outputPath, "certs")
+	if _, serr := os.Stat(certDir); os.IsNotExist(serr) {
+		log.Warn("Missing certs directory from sciond package, "+
+			"running non-standard installation?", "err", serr)
+		err := os.Mkdir(certDir, 0775)
+		if err != nil {
+			log.Error("Unable to stat or create output directory for TRCs", "serr", serr, "err", err)
+			return err
+		}
+		log.Info("Created certs directory in output path", "certDir", certDir)
+	}
 
 	if securityMode != config.Insecure {
 		// Wipe symlinks to TRCs fetched in insecure mode, if we are not using the insecure mode

--- a/hinting/hinting.go
+++ b/hinting/hinting.go
@@ -224,7 +224,8 @@ func ifaceIPv6Addrs(iface *net.Interface) (ips []netip.Addr) {
 			continue
 		}
 		ip, ok := netip.AddrFromSlice(ifaddr.IP)
-		if ok && ip.Is6() && !ip.Is4In6() {
+		// do not include IPv6 mapped IPv4 addresses and IPv6 loopback
+		if ok && ip.Is6() && !ip.Is4In6() && !ip.IsLoopback(){
 			ips = append(ips, ip)
 		}
 	}


### PR DESCRIPTION
Add build instructions and target for macOS and Windows.

Add instructions for running the non-packaged installation and generating a default configuration.

Create the `certs` directory when running independently of the scion-daemon package.