### PR TITLE
Fixes and improved error output for tests

### DIFF
--- a/fetcher/scion_cppki_verify.go
+++ b/fetcher/scion_cppki_verify.go
@@ -70,8 +70,8 @@ func verifyTopologySignature(cfg *config.Config) error {
 
 	// verify the AS certificate chain (but not the payload signature) back to the TRCs of the ISD follows the
 	// SCION CP PKI rules about cert type, key usage:
-	if err = spkiCertVerify(ctx, sortedTRCsPaths, asCertChainPath); err != nil {
-		return fmt.Errorf("unable to validate certificate chain: %w", err)
+	if stdoutStderr, err := spkiCertVerify(ctx, sortedTRCsPaths, asCertChainPath); err != nil {
+		return fmt.Errorf("unable to validate certificate chain: %s %w", stdoutStderr, err)
 	}
 
 	var unvalidatedTopologyPath string

--- a/fetcher/scion_cppki_verify_test.go
+++ b/fetcher/scion_cppki_verify_test.go
@@ -294,7 +294,7 @@ func TestExtractSignerInfo(t *testing.T) {
 	if err != nil {
 		log.Error("Failed to create signed file", "signedPayloadPath", signedPayloadPath, "err", err)
 	}
-	signerTRCid, signerIA, asCertChainPath, err := extractSignerInfo(context.WithValue(context.TODO(), "openssl", false), signedPayloadPath, tmpDir)
+	signerTRCid, signerIA, asCertChainPath, err := extractSignerInfo(context.WithValue(context.TODO(), "nativeCrypto", false), signedPayloadPath, tmpDir)
 	if err != nil {
 		log.Error("Getting signer info failed: extractSignerInfo", "err", err)
 		t.FailNow()

--- a/fetcher/scion_pki_tool_cmds.go
+++ b/fetcher/scion_pki_tool_cmds.go
@@ -16,9 +16,9 @@ func spkiTRCExtractCerts(ctx context.Context, trustAnchorTRC, rootCertsBundlePat
 
 // spkiCertVerify verifies the AS certificate asCertChainPath
 // against the sorted TRCs in the update chain trcsUpdateChain.
-func spkiCertVerify(ctx context.Context, trcsUpdateChain []string, asCertChainPath string) error {
+func spkiCertVerify(ctx context.Context, trcsUpdateChain []string, asCertChainPath string) ([]byte, error) {
 	return exec.CommandContext(ctx, "scion-pki", "certificate", "verify",
-		"--trc", strings.Join(trcsUpdateChain, ","), asCertChainPath).Run()
+		"--trc", strings.Join(trcsUpdateChain, ","), asCertChainPath).CombinedOutput()
 }
 
 // spkiTRCVerify verifies the TRC update chain for candidateTRCPath anchored in the TRCs trcUpdateChainPaths


### PR DESCRIPTION
## Description

Noticed some errors during the packages of this project in nixpkgs: https://github.com/NixOS/nixpkgs/pull/299479

1. Fixed the following error by setting `nativeCrypto` instead of `openssl`. Im unsure if this is a reasonable assumption or not:

```
--- FAIL: TestExtractSignerInfo (0.00s)
panic: interface conversion: interface {} is nil, not bool [recovered]
        panic: interface conversion: interface {} is nil, not bool

goroutine 10 [running]:
testing.tRunner.func1.2({0x629880, 0xc0000dbef0})
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1634 +0x377
panic({0x629880?, 0xc0000dbef0?})
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/runtime/panic.go:770 +0x132
github.com/netsec-ethz/bootstrapper/fetcher.smimePk7out({0x6dcaa0, 0xc0000dbec0}, {0xc000020e80, 0x38}, {0xc000020ec0, 0x40})
        /build/source/fetcher/crypto_cmds.go:22 +0x10c
github.com/netsec-ethz/bootstrapper/fetcher.extractSignerInfo({0x6dcaa0, 0xc0000dbec0}, {0xc000020e80, 0x38}, {0xc000030c00, 0x29})
        /build/source/fetcher/scion_cppki_verify.go:170 +0xd7
github.com/netsec-ethz/bootstrapper/fetcher.TestExtractSignerInfo(0xc0000f7520)
        /build/source/fetcher/scion_cppki_verify_test.go:297 +0xa08
testing.tRunner(0xc0000f7520, 0x699150)
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 1
        /nix/store/bp39dh48cdqp89hk5mpdi1lxdf0mjl7x-go-1.22.1/share/go/src/testing/testing.go:1742 +0x390
FAIL    github.com/netsec-ethz/bootstrapper/fetcher     0.026s
```

2. An outstanding certificate verification error for `TestVerify` only output the return code which was not helpful to understand which part of the PKI verification failed. The new error output makes it much clear but does not fix the test failure (spun out an issue to figure out how to best address that https://github.com/netsec-ethz/bootstrapper/issues/19).

Old output:
```
$ go test -v ./fetcher
=== RUN   TestVerify
t=2024-03-27T19:18:45+0000 lvl=eror msg="Signature verification failed: verifyTopologySignature" err="unable to validate certificate chain: exit status 1"
--- FAIL: TestVerify (0.05s)
=== RUN   TestExtractSignerInfo
--- PASS: TestExtractSignerInfo (0.01s)
=== RUN   TestWipeInsecureSymlinks
--- PASS: TestWipeInsecureSymlinks (0.00s)
FAIL
FAIL    github.com/netsec-ethz/bootstrapper/fetcher     0.067s
FAIL
```
New output:

```
$ go test -v ./fetcher
=== RUN   TestVerify
t=2024-03-27T19:22:11+0000 lvl=eror msg="Signature verification failed: verifyTopologySignature" err="unable to validate certificate chain: Error: verification failed: chain did not verify against any selected TRC {errors=[verifying chain {trc_base=1; trc_serial=1}: x509: certificate has expired or is not yet valid: current time 2024-03-27T19:22:11Z is after 2024-02-15T14:44:03Z]}\n exit status 1"
--- FAIL: TestVerify (0.02s)
=== RUN   TestExtractSignerInfo
--- PASS: TestExtractSignerInfo (0.01s)
=== RUN   TestWipeInsecureSymlinks
--- PASS: TestWipeInsecureSymlinks (0.00s)
FAIL
FAIL    github.com/netsec-ethz/bootstrapper/fetcher     0.037s
FAIL
```
