### PR TITLE
Integrate the DNS search domain fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ It uses the following hinting mechanisms:
 - DNS-SD: DNS service discovery [RFC6763]
 - mDNS: multicast DNS [RFC6762]
 
+If the host being bootstrapped has no DNS search domain set, the rDNS functionality of DNS (as described in RFC1035)
+is used to obtain a hostname and derive a search domain.
+A query for the name `reversed-external-ip.in-addr-servers.arpa.` (or `reversed-external-ip.ip6.arpa` in the case of
+IPv6) is sent to the default DNS resolver and resolved according to the delegation hierarchy.
+
+---
+**_NOTE:_**
+In case there is no DNS search domain set on the host being bootstrapped **and**
+that host has no public IP address, the *whoami* DNS service on `akamai.net` is used to resolve an
+external IP.
+As a further fallback, in case a nameserver for `akamai.net` cannot be resolved, the public DNS
+resolver `9.9.9.9` provided by Quad9, headquartered in Switzerland and subject to Swiss privacy law, is used
+to obtain the address of further nameservers.
+
+The only information reaching those services are the external IP of the host and the information
+that this host is using the *whoami* service to obtain that address.
+
+All this is only a further fallback to provide zero-configuration bootstrapping even in misconfigured networks.
+
+Calls to these two third-party services can be disabled entirely for a host by null routing their IP with the
+`ip route add 9.9.9.9 via 127.0.0.1 dev lo` command and adding the entry `127.0.0.1   akamai.net` to the hosts file.
+On the network level, calls to those fallbacks can be prevented by providing a proper DNS search domain configuration to
+the endhost using DHCP(v6) or IPv6 RAs. In split-horizon DNS settings, the response to the nameserver query for
+`akamai.net` can be shadowed if required to prevent the fallback.
+Note that other services on your system might rely on those.
+
+---
+
 It integrates with SCION by using the same OpenAPI as the control service uses
 for exposing TRCs (serving as root certificate) and the topology file
 (describing the local SCION topology).

--- a/hinting/dns_search_domain_fallbacks.go
+++ b/hinting/dns_search_domain_fallbacks.go
@@ -1,9 +1,105 @@
 package hinting
 
 import (
+	"net"
+	"net/netip"
 	"slices"
 	"strings"
 )
+
+// getFallbackSearchDomains provides DNS search domain candidates to dnsChanWritable.
+// The results are only retrieved and returned if no DNS search domains were provided by
+// the dispatcher DNSInfo channel. The number of external entities contacted is minimized.
+// The domains are obtained from reverse DNS lookups and alternatively whois contact info,
+// and returned along with the resolvers learned from the dispatcher DNSInfo channel.
+func getFallbackSearchDomains(dnsChanWritable chan<- DNSInfo) {
+	resolverSet := make(map[netip.Addr]struct{})
+	searchDomainSet := make(map[string]struct{})
+	// fallback for DNS search domains was started, so dnsInfoDispatcher hinting.dispatcher
+	// was already started.
+	dnsChanReadable := dispatcher.getDNSConfig()
+Fallback:
+	for {
+		select {
+		case dnsInfo := <-dnsChanReadable:
+			// collect info from happy path
+			for _, resolver := range dnsInfo.resolvers {
+				resolverSet[resolver] = struct{}{}
+			}
+			for _, searchDomain := range dnsInfo.searchDomains {
+				searchDomainSet[searchDomain] = struct{}{}
+			}
+		case <-dnsInfoDone:
+			// start with fallback
+			break Fallback
+		}
+	}
+	if len(searchDomainSet) > 0 {
+		// do not attempt fallback as authoritative locally configured
+		// search domains were found.
+		return
+	}
+
+	// Collect domain information from DNS reverse lookup
+	ips := getPublicAddresses()
+	if len(ips) == 0 {
+		// attempt fallback to reverse lookup of externally observed IP,
+		// if all configured IPs are private.
+		ip, err := queryExternalIP()
+		if err == nil {
+			ips = append(ips, *ip)
+		}
+	}
+
+	for _, ip := range ips {
+		domains := reverseLookupDomains(ip)
+		for _, searchDomain := range domains {
+			searchDomainSet[searchDomain] = struct{}{}
+		}
+	}
+
+	resolvers := make([]netip.Addr, 0, len(resolverSet))
+	for k := range resolverSet {
+		resolvers = append(resolvers, k)
+	}
+	searchDomains := make([]string, 0, len(searchDomainSet))
+	for k := range searchDomainSet {
+		searchDomains = append(searchDomains, k)
+	}
+	dnsInfo := DNSInfo{resolvers: resolvers, searchDomains: searchDomains}
+	dnsInfoWriters.Add(1)
+	select {
+	case <-dnsInfoFallbackDone:
+		// Ignore dnsInfo value, done publishing
+	default:
+		dnsChanWritable <- dnsInfo
+	}
+	dnsInfoWriters.Done()
+	return
+}
+
+func getPublicAddresses() (ips []netip.Addr) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip, err := netip.ParseAddr(addr.String())
+			if err != nil {
+				continue
+			}
+			if !ip.IsPrivate() {
+				ips = append(ips, ip)
+			}
+		}
+	}
+	return
+}
 
 func domainsFromHostnames(hostnames []string) (domains []string) {
 	for _, hostname := range hostnames {

--- a/hinting/dns_search_domain_fallbacks_reverse.go
+++ b/hinting/dns_search_domain_fallbacks_reverse.go
@@ -39,6 +39,12 @@ func getAkaNS() (nameserver string, err error) {
 	if err == nil {
 		return nameservers[rand.Intn(len(nameservers))].Host, err
 	}
+	if err, ok := err.(*net.DNSError); ok && err.IsNotFound {
+		// Do not attempt further fallback to a public resolver.
+		// We got a NXDOMAIN response or no NS type response. Since we know the NS record exists,
+		// it must have been intentionally shadowed by the system default resolver.
+		return nil, err
+	}
 
 	m := new(dns.Msg)
 	m.SetQuestion(akamaiDomain, dns.TypeNS)

--- a/hinting/dns_search_domain_fallbacks_reverse.go
+++ b/hinting/dns_search_domain_fallbacks_reverse.go
@@ -3,10 +3,12 @@ package hinting
 import (
 	"context"
 	"errors"
-	"github.com/miekg/dns"
 	"math/rand"
 	"net"
 	"net/netip"
+	"time"
+
+	"github.com/miekg/dns"
 )
 
 var (
@@ -31,7 +33,8 @@ func reverseLookupDomains(addr netip.Addr) (domains []string) {
 func getAkaNS() (nameserver string, err error) {
 	// try default resolver
 	resolver := net.Resolver{}
-	ctx := context.TODO()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(DNSInfoTimeoutFallback-DNSInfoTimeout))
+	defer cancel()
 	nameservers, err := resolver.LookupNS(ctx, akamaiDomain)
 	if err == nil {
 		return nameservers[rand.Intn(len(nameservers))].Host, err


### PR DESCRIPTION
Make use of the DNS search domain fallbacks:
If no DNS search domain is discovered by the other hinters before the timeout is about to expire, use the public IP(s) of the host and reverse DNS to discover candidate DNS search domains. If there are no public IPs, use external DNS servers to discover publicly reachable IPs.