### PR TITLE
search domain discovery: add whois lookup fallback

### DIFF
--- a/hinting/dns_search_domain_fallbacks.go
+++ b/hinting/dns_search_domain_fallbacks.go
@@ -63,7 +63,7 @@ Fallback:
 		// attempt fallback to WHOIS contact information heuristics as
 		// reverse DNS lookups provided no results.
 		for _, ip := range ips {
-			domains := reverseLookupWhois(ip)
+			domains := reverseLookupWHOIS(ip)
 			for _, searchDomain := range domains {
 				searchDomainSet[searchDomain] = struct{}{}
 			}

--- a/hinting/dns_search_domain_fallbacks.go
+++ b/hinting/dns_search_domain_fallbacks.go
@@ -58,6 +58,18 @@ Fallback:
 		}
 	}
 
+	// Collect domain information from WHOIS contact information
+	if len(searchDomainSet) == 0 {
+		// attempt fallback to WHOIS contact information heuristics as
+		// reverse DNS lookups provided no results.
+		for _, ip := range ips {
+			domains := reverseLookupWhois(ip)
+			for _, searchDomain := range domains {
+				searchDomainSet[searchDomain] = struct{}{}
+			}
+		}
+	}
+
 	resolvers := make([]netip.Addr, 0, len(resolverSet))
 	for k := range resolverSet {
 		resolvers = append(resolvers, k)

--- a/hinting/dns_search_domain_fallbacks_whois.go
+++ b/hinting/dns_search_domain_fallbacks_whois.go
@@ -6,8 +6,6 @@ import (
 	"net/mail"
 	"net/netip"
 	"slices"
-
-	//"slices"
 	"strings"
 )
 
@@ -22,15 +20,15 @@ var (
 	}
 )
 
-func reverseLookupWhois(addr netip.Addr) (domains []string) {
-	response, err := resolveWhoisRedirects(addr, ianaWHOIS)
+func reverseLookupWHOIS(addr netip.Addr) (domains []string) {
+	response, err := resolveWHOISRedirects(addr, ianaWHOIS)
 	if err != nil {
 		return
 	}
 	return extractEmailDomains(response)
 }
 
-func resolveWhoisRedirects(addr netip.Addr, server string) (response string, err error) {
+func resolveWHOISRedirects(addr netip.Addr, server string) (response string, err error) {
 	whoisServer := server
 	for i := 0; i < 10; i++ {
 		// arbitrary upper limit of 10 redirects allowed, usually no more than 3 (IANA, RIR legacy registration, RIR)
@@ -39,7 +37,7 @@ func resolveWhoisRedirects(addr netip.Addr, server string) (response string, err
 		if err != nil {
 			return
 		}
-		response, err = queryWhois(raddr, addr)
+		response, err = queryWHOIS(raddr, addr)
 		if err != nil {
 			return
 		}
@@ -61,17 +59,7 @@ func resolveWhoisRedirects(addr netip.Addr, server string) (response string, err
 		if strings.HasPrefix(entry, "ReferralServer:") {
 			value := strings.TrimPrefix(entry, "ReferralServer:")
 			whoisRefer := strings.TrimPrefix(strings.TrimSpace(value), "whois://")
-			//if slices.Contains(rirWHOIS, whoisRefer) {
-			//	whoisServer = whoisRefer
-			//	continue
-			//}
-			match := false
-			for _, rserver := range rirWHOIS {
-				if match = rserver == whoisRefer; match {
-					break
-				}
-			}
-			if match {
+			if slices.Contains(rirWHOIS, whoisRefer) {
 				whoisServer = whoisRefer
 				continue
 			}
@@ -81,7 +69,7 @@ func resolveWhoisRedirects(addr netip.Addr, server string) (response string, err
 	return
 }
 
-func queryWhois(serverTCPAddr *net.TCPAddr, queryAddr netip.Addr) (response string, err error) {
+func queryWHOIS(serverTCPAddr *net.TCPAddr, queryAddr netip.Addr) (response string, err error) {
 	var tcpConn *net.TCPConn
 	var responseBuff []byte
 	tcpConn, err = net.DialTCP("tcp", nil, serverTCPAddr)

--- a/hinting/dns_search_domain_fallbacks_whois.go
+++ b/hinting/dns_search_domain_fallbacks_whois.go
@@ -1,0 +1,127 @@
+package hinting
+
+import (
+	"io"
+	"net"
+	"net/mail"
+	"net/netip"
+	"slices"
+
+	//"slices"
+	"strings"
+)
+
+var (
+	ianaWHOIS = "whois.iana.org"
+	rirWHOIS  = []string{
+		"whois.afrinic.net",
+		"whois.lacnic.net",
+		"whois.apnic.net",
+		"whois.ripe.net",
+		"whois.arin.net",
+	}
+)
+
+func reverseLookupWhois(addr netip.Addr) (domains []string) {
+	response, err := resolveWhoisRedirects(addr, ianaWHOIS)
+	if err != nil {
+		return
+	}
+	return extractEmailDomains(response)
+}
+
+func resolveWhoisRedirects(addr netip.Addr, server string) (response string, err error) {
+	whoisServer := server
+	for i := 0; i < 10; i++ {
+		// arbitrary upper limit of 10 redirects allowed, usually no more than 3 (IANA, RIR legacy registration, RIR)
+		var raddr *net.TCPAddr
+		raddr, err = net.ResolveTCPAddr("tcp4", net.JoinHostPort(whoisServer, "43"))
+		if err != nil {
+			return
+		}
+		response, err = queryWhois(raddr, addr)
+		if err != nil {
+			return
+		}
+		var entry string
+		for _, entry = range strings.Split(response, "\n") {
+			if strings.HasPrefix(entry, "refer:") ||
+				strings.HasPrefix(entry, "ReferralServer:") {
+				break
+			}
+		}
+		if strings.HasPrefix(entry, "refer:") {
+			value := strings.TrimPrefix(entry, "refer:")
+			whoisRefer := strings.TrimSpace(value)
+			if slices.Contains(rirWHOIS, whoisRefer) {
+				whoisServer = whoisRefer
+				continue
+			}
+		}
+		if strings.HasPrefix(entry, "ReferralServer:") {
+			value := strings.TrimPrefix(entry, "ReferralServer:")
+			whoisRefer := strings.TrimPrefix(strings.TrimSpace(value), "whois://")
+			//if slices.Contains(rirWHOIS, whoisRefer) {
+			//	whoisServer = whoisRefer
+			//	continue
+			//}
+			match := false
+			for _, rserver := range rirWHOIS {
+				if match = rserver == whoisRefer; match {
+					break
+				}
+			}
+			if match {
+				whoisServer = whoisRefer
+				continue
+			}
+		}
+		break
+	}
+	return
+}
+
+func queryWhois(serverTCPAddr *net.TCPAddr, queryAddr netip.Addr) (response string, err error) {
+	var tcpConn *net.TCPConn
+	var responseBuff []byte
+	tcpConn, err = net.DialTCP("tcp", nil, serverTCPAddr)
+	if err != nil {
+		return
+	}
+	defer tcpConn.Close()
+	if _, err = tcpConn.Write([]byte(queryAddr.String() + "\n")); err != nil {
+		return
+	}
+	responseBuff, err = io.ReadAll(tcpConn)
+	if err != nil {
+		return
+	}
+	response = string(responseBuff)
+	return
+}
+
+func extractEmailDomains(response string) (domains []string) {
+	var emailsFields []string
+	for _, entry := range strings.Split(response, "\n") {
+		if strings.Contains(entry, "abuse@") ||
+			strings.Contains(entry, "security@") ||
+			strings.Contains(entry, "noc@") {
+			fields := strings.Fields(entry)
+			for _, field := range fields {
+				if strings.Contains(field, "@") {
+					emailsFields = append(emailsFields, field)
+				}
+			}
+		}
+	}
+	var hostnames []string
+	for _, email := range emailsFields {
+		if address, err := mail.ParseAddress(email); err == nil {
+			addressLabels := strings.Split(address.Address, "@")
+			domain := "." + strings.Trim(addressLabels[len(addressLabels)-1], "'.")
+			hostnames = append(hostnames, domain)
+		}
+	}
+	// filter out RIR domains
+	return domainsFromHostnames(hostnames)
+}


### PR DESCRIPTION
Add fallback feature for discovering a valid search domain by looking up the contact information for the external public IP and deriving potential search domains from the contact addresses.