### PR TITLE
DNS search domains fallback test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 
 replace github.com/insomniacslk/dhcp => github.com/stapelberg/dhcp v0.0.0-20190429172946-5244c0daddf0
 
-go 1.21
+go 1.22

--- a/hinting/dns.go
+++ b/hinting/dns.go
@@ -16,7 +16,7 @@
 package hinting
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"sort"
@@ -214,10 +214,10 @@ func (s byPriority) Less(i, j int) bool {
 		return false
 	} else {
 		if s[i].Weight == 0 && s[j].Weight == 0 {
-			return rand.Intn(2) == 0
+			return rand.IntN(2) == 0
 		}
 		max := int(s[i].Weight) + int(s[j].Weight)
-		return rand.Intn(max) < int(s[i].Weight)
+		return rand.IntN(max) < int(s[i].Weight)
 	}
 }
 

--- a/hinting/dns_search_domain_fallbacks.go
+++ b/hinting/dns_search_domain_fallbacks.go
@@ -47,7 +47,7 @@ Fallback:
 		// if all configured IPs are private.
 		ip, err := queryExternalIP()
 		if err == nil {
-			ips = append(ips, *ip)
+			ips = append(ips, ip)
 		}
 	}
 
@@ -96,16 +96,17 @@ func getPublicAddresses() (ips []netip.Addr) {
 		return
 	}
 	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
+		ifaddrs, err := iface.Addrs()
 		if err != nil {
 			continue
 		}
-		for _, addr := range addrs {
-			ip, err := netip.ParseAddr(addr.String())
-			if err != nil {
+		for _, ifaddr := range ifaddrs {
+			ifaddr, ok := ifaddr.(*net.IPNet)
+			if !ok {
 				continue
 			}
-			if !ip.IsPrivate() {
+			ip, ok := netip.AddrFromSlice(ifaddr.IP)
+			if ok && !ip.IsPrivate() {
 				ips = append(ips, ip)
 			}
 		}

--- a/hinting/dns_search_domain_fallbacks_reverse.go
+++ b/hinting/dns_search_domain_fallbacks_reverse.go
@@ -3,7 +3,7 @@ package hinting
 import (
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"time"
@@ -37,13 +37,13 @@ func getAkaNS() (nameserver string, err error) {
 	defer cancel()
 	nameservers, err := resolver.LookupNS(ctx, akamaiDomain)
 	if err == nil {
-		return nameservers[rand.Intn(len(nameservers))].Host, err
+		return nameservers[rand.IntN(len(nameservers))].Host, err
 	}
 	if err, ok := err.(*net.DNSError); ok && err.IsNotFound {
 		// Do not attempt further fallback to a public resolver.
 		// We got a NXDOMAIN response or no NS type response. Since we know the NS record exists,
 		// it must have been intentionally shadowed by the system default resolver.
-		return nil, err
+		return "", err
 	}
 
 	m := new(dns.Msg)
@@ -57,7 +57,7 @@ func getAkaNS() (nameserver string, err error) {
 		err = errors.New("getAkaNS: No DNS RR answer")
 		return "", err
 	}
-	if ns, ok := in.Answer[rand.Intn(len(in.Answer))].(*dns.NS); ok {
+	if ns, ok := in.Answer[rand.IntN(len(in.Answer))].(*dns.NS); ok {
 		return ns.Ns, nil
 	}
 	return "", errors.New("getAkaNS: Invalid NS record")

--- a/hinting/dns_search_domain_fallbacks_test.go
+++ b/hinting/dns_search_domain_fallbacks_test.go
@@ -35,7 +35,6 @@ func TestReverseLookupDomains(t *testing.T) {
 				domain string
 			}{
 				{ip: netip.MustParseAddr("66.180.178.131"), domain: "princeton.edu"},
-				//{ip: randIPFromCIDR("128.112.0.0/16"), domain: "princeton.edu"},
 				{ip: randIPFromCIDR("128.112.66.0/23"), domain: "princeton.edu"},
 			},
 		},
@@ -66,7 +65,6 @@ func TestReverseLookupDomains(t *testing.T) {
 				ip     netip.Addr
 				domain string
 			}{
-				//{ip: netip.MustParseAddr("203.250.215.48"), domain: "kreonet.net"},
 				{ip: netip.MustParseAddr("134.75.254.11"), domain: "kreonet.net"},
 				{ip: netip.MustParseAddr("134.75.254.12"), domain: "kreonet.net"},
 			},
@@ -88,6 +86,81 @@ func TestReverseLookupDomains(t *testing.T) {
 		for _, v := range tc.values {
 			t.Log(v.ip)
 			res := reverseLookupDomains(v.ip)
+			t.Log(res)
+			assert.Subset(t, res, []string{v.domain}, "")
+		}
+	}
+}
+
+func TestReverseLookupWHOIS(t *testing.T) {
+
+	testCases := []struct {
+		name   string
+		values []struct {
+			ip     netip.Addr
+			domain string
+		}
+	}{
+		{
+			name: "ETHZ",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("129.132.19.216"), domain: "ethz.ch"},
+			},
+		},
+		{
+			name: "PU",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("128.112.0.11"), domain: "princeton.edu"},
+			},
+		},
+		{
+			name: "VU",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("128.143.3.126"), domain: "virginia.edu"},
+			},
+		},
+		{
+			name: "SWITCH",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("130.59.31.35"), domain: "switch.ch"},
+			},
+		},
+		{
+			name: "KREONET",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("203.250.215.48"), domain: "kreonet.net"},
+			},
+		},
+		{
+			name: "KU",
+			values: []struct {
+				ip     netip.Addr
+				domain string
+			}{
+				{ip: netip.MustParseAddr("163.152.6.1"), domain: "korea.ac.kr"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Log(tc.name)
+		for _, v := range tc.values {
+			t.Log(v.ip)
+			res := reverseLookupWhois(v.ip)
 			t.Log(res)
 			assert.Subset(t, res, []string{v.domain}, "")
 		}

--- a/hinting/dns_search_domain_fallbacks_whois.go
+++ b/hinting/dns_search_domain_fallbacks_whois.go
@@ -111,5 +111,13 @@ func extractEmailDomains(response string) (domains []string) {
 		}
 	}
 	// filter out RIR domains
-	return domainsFromHostnames(hostnames)
+	filteredHostnames := hostnames[:0] // in place slice filter: https://go.dev/wiki/SliceTricks
+	for _, hostname := range hostnames {
+		for _, rir := range rirWHOIS {
+			if !strings.HasSuffix(hostname, strings.TrimPrefix(rir, "whois.")) {
+				filteredHostnames = append(filteredHostnames, hostname)
+			}
+		}
+	}
+	return domainsFromHostnames(filteredHostnames)
 }

--- a/hinting/hinting.go
+++ b/hinting/hinting.go
@@ -172,17 +172,20 @@ func initDispatcher() (dnsChan <-chan DNSInfo) {
 	// Signal dnsInfoChan fallback senders after timeout
 	dnsInfoTimeoutFallback := time.After(DNSInfoTimeoutFallback)
 	go func() {
-		select {
-		case <-dnsInfoTimeout:
-			// Signal senders about timeout
-			close(dnsInfoDone)
-		case <-dnsInfoTimeoutFallback:
-			// Signal fallback about timeout
-			close(dnsInfoFallbackDone)
-			// Wait for remaining senders
-			dnsInfoWriters.Wait()
-			// Stop publishing new DNSInfo
-			close(dnsInfoChan)
+		for {
+			select {
+			case <-dnsInfoTimeout:
+				// Signal senders about timeout
+				close(dnsInfoDone)
+			case <-dnsInfoTimeoutFallback:
+				// Signal fallback about timeout
+				close(dnsInfoFallbackDone)
+				// Wait for remaining senders
+				dnsInfoWriters.Wait()
+				// Stop publishing new DNSInfo
+				close(dnsInfoChan)
+				return
+			}
 		}
 	}()
 	return


### PR DESCRIPTION

DNS search domain fallbacks: increase test coverage by randomly picking IP from address space
Add `TestWHOISInfo` helper test allowing to easily manually test WHOIS results
Update Go version to current scionproto master
Replace usage of deprecated package with math/rand/v2