### PR TITLE
Use next hint in case a hint fails.

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"sync"
 	"time"
@@ -95,22 +96,31 @@ func (b *Bootstrapper) tryBootstrapping() error {
 		wg.Wait()
 		close(hintersDone)
 	}()
+	seenIPs := make(map[netip.AddrPort]bool)
 OuterLoop:
 	for {
 		select {
 		case ipAddr := <-b.ipHintsChan:
+			serverAddr := &ipAddr
+			if serverAddr.Port == 0 {
+				serverAddr.Port = int(hinting.DiscoveryPort)
+			}
+			addrPort := serverAddr.AddrPort()
+			if seenIPs[addrPort] {
+				log.Info("Ignoring previously seen hint", "hint", ipAddr)
+				continue
+			}
+			// Mark the ip as having been seen before, to prevent duplicate queries.
+			seenIPs[addrPort] = true
 			if err := checkIsRoutable(ipAddr.IP); err != nil {
 				// Ignore IPv6 hints if device does not have an IPv6 address, etc.
 				log.Debug("Ignore hint, no route", "hint", ipAddr, "err", err)
 				continue
 			}
-			serverAddr := &ipAddr
-			if serverAddr.Port == 0 {
-				serverAddr.Port = int(hinting.DiscoveryPort)
-			}
 			err := fetcher.FetchConfiguration(&cfg, serverAddr)
 			if err != nil {
-				return err
+				log.Debug("Failed to fetch configuration from server", "server", serverAddr, "err", err)
+				continue
 			}
 			break OuterLoop
 		case <-hintsTimeout:


### PR DESCRIPTION
When bootstrapping at ETH on freshly installed hosts that have some sort of IPv6 connectivity, the bootstrapper uses an IPv6 hint, which fails with a context deadline exceeded error. While there is a check whether an IPv6 address is routable, this check (erroneously?) does allow the bootstrapper to use IPv6 hints that are in fact not reachable. This PR circumvents the problem by using the next available hint, if this hint is different than previous hints. In the ETH case, falling back to an IPv4 hint, which does succeed.

Relevant logging:
```
t=2025-02-07T09:51:24+0000 lvl=info msg="DNS hint" Addr="{IP:2001:67c:10ec:3544::26 Port:8041 Zone:}"
t=2025-02-07T09:51:24+0000 lvl=info msg="Fetching TRCs index" url=http://[2001:67c:10ec:3544::26]:8041/trcs
t=2025-02-07T09:51:24+0000 lvl=info msg="DNS hint" Addr="{IP:129.132.121.175 Port:8041 Zone:}"
t=2025-02-07T09:51:24+0000 lvl=info msg="DHCP hinting done"
t=2025-02-07T09:51:26+0000 lvl=eror msg="Failed to fetch TRCs index from http://[2001:67c:10ec:3544::26]:8041/trcs" err="HTTP request failed: c>
t=2025-02-07T09:51:26+0000 lvl=eror msg="Bootstrapping failed" err="HTTP request failed: context deadline exceeded"
t=2025-02-07T09:51:26+0000 lvl=info msg="=====================> Service stopped bootstrapper"
scion-bootstrapper@eno2.service: Main process exited, code=exited, status=1/FAILURE
scion-bootstrapper@eno2.service: Failed with result 'exit-code'.
Failed to start scion-bootstrapper@eno2.service - SCION Endhost Bootstrapper.
```
